### PR TITLE
Fix: Correct post-login redirect and repair navbar links

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -4,9 +4,9 @@
 
  
  const ROLE_REDIRECT: Record<string, string> = {
-   SCOUT: "/scout",
-   RECRUITER: "/recruiter",
-   AGENT: "/agent",
+   SCOUT: "/reports/new",
+   RECRUITER: "/reports/new",
+   AGENT: "/reports/new",
    ADMIN: "/admin",
  };
  

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -46,15 +46,14 @@ export function Navbar() {
 
         {/* Navigation desktop */}
         <nav className="hidden md:flex items-center gap-6 text-sm">
-          <a href="#" className="hover:text-primary text-slate-600">
-            Scouts
-          </a>
-          <a href="#" className="hover:text-primary text-slate-600">
-            Recruteurs
-          </a>
-          <a href="#" className="hover:text-primary text-slate-600">
-            Agents
-          </a>
+          {session && (
+            <a
+              href="/reports/new"
+              className="hover:text-primary text-slate-600"
+            >
+              Nouveau rapport
+            </a>
+          )}
           {session ? (
             <>
               <a href="/profile" className="hover:text-primary text-slate-600">
@@ -82,15 +81,14 @@ export function Navbar() {
       {open && (
         <div className="md:hidden border-t border-slate-200 bg-white">
           <nav className="px-4 py-4 flex flex-col gap-4 text-sm">
-            <a href="#" className="hover:text-primary text-slate-700">
-              Scouts
-            </a>
-            <a href="#" className="hover:text-primary text-slate-700">
-              Recruteurs
-            </a>
-            <a href="#" className="hover:text-primary text-slate-700">
-              Agents
-            </a>
+            {session && (
+              <a
+                href="/reports/new"
+                className="hover:text-primary text-slate-700"
+              >
+                Nouveau rapport
+              </a>
+            )}
             {session ? (
               <>
                 <a href="/profile" className="hover:text-primary text-slate-700">


### PR DESCRIPTION
This commit addresses a critical issue where users would encounter a 404 error page after logging in, preventing them from accessing any part of the application, including their personal profile page.

The root cause was twofold:
1. The post-login redirection logic in `src/app/app/page.tsx` was pointing to non-existent pages (e.g., `/scout`, `/players`). The application is missing list pages for players and reports.
2. The main navigation bar in `src/components/Navbar.tsx` contained dead links (`href="#"`), leaving users with no way to navigate the site.

This commit implements the following fixes:
- Updates `src/app/app/page.tsx` to redirect all non-admin roles to `/reports/new`, which is a functional, existing page that users have permission to access.
- Modifies `src/components/Navbar.tsx` to remove the dead links and replace them with a single, valid link to "Nouveau rapport" (`/reports/new`) for both desktop and mobile views.

These changes ensure that users are directed to a working page upon login, from which they can access their personal space ("Mon profil") via the now-visible and functional navigation bar.