### PR TITLE
Replace deprecated getServerSession usage with auth helper

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,4 @@
 // src/app/(auth)/login/page.tsx
-import { getServerSession } from "next-auth";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import LoginForm from "./LoginForm";
@@ -12,18 +11,26 @@ import LoginForm from "./LoginForm";
  * @returns {Promise<JSX.Element>} Le composant de la page de connexion.
  */
 export default async function LoginPage() {
-const session = await getServerSession(auth);
-if (session) redirect("/app"); // redispatch par rôle
-return (
-<>
-<h1 className="text-2xl font-semibold">Connexion</h1>
-<p className="text-sm text-slate-400 mt-1">Accédez à votre espace personnel.</p>
-<LoginForm />
-<div className="mt-4 text-sm text-slate-400">
-<a href="/register" className="underline">Créer un compte</a>
-<span className="mx-2">•</span>
-<a href="/forgot-password" className="underline">Mot de passe oublié ?</a>
-</div>
-</>
-);
+  const session = await auth();
+
+  if (session) redirect("/app"); // redispatch par rôle
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold">Connexion</h1>
+      <p className="text-sm text-slate-400 mt-1">
+        Accédez à votre espace personnel.
+      </p>
+      <LoginForm />
+      <div className="mt-4 text-sm text-slate-400">
+        <a href="/register" className="underline">
+          Créer un compte
+        </a>
+        <span className="mx-2">•</span>
+        <a href="/forgot-password" className="underline">
+          Mot de passe oublié ?
+        </a>
+      </div>
+    </>
+  );
 }

--- a/src/app/api/reports/[id]/submit/route.ts
+++ b/src/app/api/reports/[id]/submit/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
 import { auth } from "@/lib/auth";
 import { PrismaClient } from "@prisma/client";
 
@@ -10,7 +9,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const session = await getServerSession(auth);
+  const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const report = await prisma.report.update({

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,5 +1,4 @@
  import { NextRequest, NextResponse } from "next/server";
- import { getServerSession } from "next-auth";
  import { auth } from "@/lib/auth";
  import { PrismaClient } from "@prisma/client";
  
@@ -7,7 +6,7 @@
  
 // GET /api/reports -> list reports for the authenticated user
 export async function GET() {
-  const session = await getServerSession(auth);
+  const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const reports = await prisma.report.findMany({
@@ -18,7 +17,7 @@ export async function GET() {
 
  // POST /api/reports  -> créer un rapport (draft)
  export async function POST(req: NextRequest) {
-   const session = await getServerSession(auth);
+   const session = await auth();
    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
  
    const { playerId, title, content } = await req.json();

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
 import { auth } from "@/lib/auth";
 
 /**
@@ -8,7 +7,7 @@ import { auth } from "@/lib/auth";
  * The old role-based redirect logic is now obsolete with the new unified dashboard.
  */
 export default async function AppGate() {
-  const session = await getServerSession(auth);
+  const session = await auth();
 
   if (!session) {
     // Should be caught by middleware, but as a fallback.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import { getServerSession } from "next-auth";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { QuickActions } from "@/components/dashboard/QuickActions";
@@ -65,7 +64,7 @@ function RecruiterAgentDashboard() {
  * @returns {Promise<JSX.Element>} Le composant de la page du tableau de bord.
  */
 export default async function DashboardPage() {
-  const session = await getServerSession(auth);
+  const session = await auth();
 
   if (!session) {
     redirect("/login");

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,4 +1,3 @@
-import { getServerSession } from "next-auth";
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { Navbar } from "@/components/Navbar";
@@ -11,7 +10,7 @@ import { Navbar } from "@/components/Navbar";
  * @returns {Promise<JSX.Element>} Le composant de la page de profil.
  */
 export default async function ProfilePage() {
-  const session = await getServerSession(auth) as {
+  const session = (await auth()) as {
     user?: {
       name?: string;
       email?: string;


### PR DESCRIPTION
## Summary
- swap deprecated `getServerSession` imports for the new `auth()` helper across server components and routes
- ensure login page formatting while relying on `auth()` for existing session detection

## Testing
- npm run lint *(fails: pre-existing lint errors in src/lib/auth.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c7fa35a48333aa53c083d2eda17c