### PR TITLE
feat: make dashboard data-driven and add reporting flows

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,34 +1,71 @@
- import { NextRequest, NextResponse } from "next/server";
- import { auth } from "@/lib/auth";
- import { PrismaClient } from "@prisma/client";
- 
- const prisma = new PrismaClient();
- 
-// GET /api/reports -> list reports for the authenticated user
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+// GET /api/reports -> liste des rapports de l'utilisateur authentifié
 export async function GET() {
   const session = await auth();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const reports = await prisma.report.findMany({
     where: { authorId: session.user.id },
+    include: {
+      player: {
+        select: { id: true, name: true, position: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
   });
+
   return NextResponse.json(reports);
 }
 
- // POST /api/reports  -> créer un rapport (draft)
- export async function POST(req: NextRequest) {
-   const session = await auth();
-   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
- 
-   const { playerId, title, content } = await req.json();
-   const report = await prisma.report.create({
-     data: {
-       authorId: session.user.id,
-       playerId,
-       title,
-       content,
-     },
-   });
- 
-   return NextResponse.json(report);
- }
+// POST /api/reports -> créer un nouveau rapport
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const playerId = body?.playerId as string | undefined;
+  const content = body?.content as string | undefined;
+  const status = body?.status as string | undefined;
+
+  if (!playerId || !content) {
+    return NextResponse.json(
+      { error: "Les champs 'playerId' et 'content' sont obligatoires." },
+      { status: 400 },
+    );
+  }
+
+  const player = await prisma.player.findUnique({
+    where: { id: playerId },
+    select: { id: true },
+  });
+
+  if (!player) {
+    return NextResponse.json(
+      { error: "Le joueur sélectionné est introuvable." },
+      { status: 400 },
+    );
+  }
+
+  const report = await prisma.report.create({
+    data: {
+      authorId: session.user.id,
+      playerId,
+      content,
+      status: status && status.length > 0 ? status : undefined,
+    },
+    include: {
+      player: {
+        select: { id: true, name: true, position: true },
+      },
+    },
+  });
+
+  return NextResponse.json(report, { status: 201 });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,56 +1,101 @@
-import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { QuickActions } from "@/components/dashboard/QuickActions";
-import { MyReports } from "@/components/dashboard/MyReports";
+import { MyReports, type DashboardReport } from "@/components/dashboard/MyReports";
 import { KpiCharts } from "@/components/dashboard/KpiCharts";
 import { QuickFavorites } from "@/components/dashboard/QuickFavorites";
 import { ReportRequests } from "@/components/dashboard/ReportRequests";
+import { PlayerFilters } from "@/components/dashboard/PlayerFilters";
+import { LogoutButton } from "@/components/auth/LogoutButton";
 
-/**
- * @component ScoutDashboard
- * @description Affiche le tableau de bord spécifique pour les utilisateurs avec le rôle "SCOUT".
- * @returns {JSX.Element} Le tableau de bord pour les scouts.
- */
-function ScoutDashboard() {
+type UserRole = "SCOUT" | "RECRUITER" | "AGENT" | "ADMIN";
+
+const roleLabels: Record<UserRole, string> = {
+  SCOUT: "Scout",
+  RECRUITER: "Recruteur",
+  AGENT: "Agent",
+  ADMIN: "Administrateur",
+};
+
+const lastReportFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+});
+
+type DashboardMetric = {
+  label: string;
+  value: string;
+};
+
+function DashboardHero({
+  name,
+  roleLabel,
+  metrics,
+}: {
+  name: string;
+  roleLabel: string;
+  metrics: DashboardMetric[];
+}) {
   return (
-    <div>
-      <h1 className="text-3xl font-bold text-white">Tableau de bord Scout</h1>
-      <div className="mt-6 grid grid-cols-12 gap-6">
-        <div className="col-span-12 lg:col-span-8">
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-sm text-slate-400">Bonjour, {name}</p>
+          <h1 className="text-3xl font-bold text-white">
+            Tableau de bord {roleLabel.toLowerCase()}
+          </h1>
+        </div>
+        <LogoutButton />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {metrics.map((metric) => (
+          <div
+            key={metric.label}
+            className="rounded-2xl bg-slate-900/50 p-4 ring-1 ring-white/10"
+          >
+            <p className="text-xs uppercase tracking-wide text-slate-400">
+              {metric.label}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">
+              {metric.value}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ScoutDashboard({ reports }: { reports: DashboardReport[] }) {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-12 gap-6">
+        <div className="col-span-12 xl:col-span-8 space-y-6">
           <KpiCharts />
+          <MyReports reports={reports} />
         </div>
-        <div className="col-span-12 lg:col-span-4">
+        <div className="col-span-12 xl:col-span-4 space-y-6">
           <QuickActions />
-        </div>
-        <div className="col-span-12">
-          <MyReports />
-        </div>
-        <div className="col-span-12">
           <QuickFavorites />
         </div>
-        <div className="col-span-12">
-          <ReportRequests />
-        </div>
       </div>
+      <ReportRequests />
     </div>
   );
 }
 
-import { PlayerFilters } from "@/components/dashboard/PlayerFilters";
-
-/**
- * @component RecruiterAgentDashboard
- * @description Affiche le tableau de bord pour les utilisateurs avec les rôles "RECRUITER" ou "AGENT".
- * @returns {JSX.Element} Le tableau de bord pour les recruteurs et agents.
- */
-function RecruiterAgentDashboard() {
+function CollaborativeDashboard({ reports }: { reports: DashboardReport[] }) {
   return (
-    <div>
-      <h1 className="text-3xl font-bold text-white">Tableau de bord Recruteur / Agent</h1>
-      <div className="mt-6 grid grid-cols-12 gap-6">
-        <div className="col-span-12">
-          <PlayerFilters />
-        </div>
+    <div className="grid grid-cols-12 gap-6">
+      <div className="col-span-12 xl:col-span-8 space-y-6">
+        <PlayerFilters />
+        <MyReports reports={reports} />
+      </div>
+      <div className="col-span-12 xl:col-span-4 space-y-6">
+        <QuickActions />
+        <QuickFavorites />
       </div>
     </div>
   );
@@ -61,25 +106,69 @@ function RecruiterAgentDashboard() {
  * @description Page principale du tableau de bord.
  * Récupère la session de l'utilisateur et affiche le tableau de bord correspondant à son rôle.
  * Redirige vers la page de connexion si l'utilisateur n'est pas authentifié.
- * @returns {Promise<JSX.Element>} Le composant de la page du tableau de bord.
  */
 export default async function DashboardPage() {
   const session = await auth();
 
-  if (!session) {
+  if (!session?.user?.id) {
     redirect("/login");
   }
 
-  const role =
-    session && typeof session === "object" && "user" in session && session.user
-      ? (session.user as { role?: string }).role
-      : undefined;
+  const userId = session.user.id;
+  const role = (session.user.role ?? "SCOUT") as UserRole;
+
+  const [recentReports, totalReports, playersCount] = await Promise.all([
+    prisma.report.findMany({
+      where: { authorId: userId },
+      include: {
+        player: {
+          select: { id: true, name: true, position: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+    }),
+    prisma.report.count({ where: { authorId: userId } }),
+    prisma.player.count(),
+  ]);
+
+  const lastReportDate = recentReports[0]?.createdAt ?? null;
+
+  const displayName =
+    [session.user.firstname, session.user.lastname].filter(Boolean).join(" ") ||
+    session.user.name ||
+    session.user.email ||
+    "Utilisateur";
+
+  const metrics: DashboardMetric[] = [
+    { label: "Rapports rédigés", value: totalReports.toString() },
+    { label: "Joueurs suivis", value: playersCount.toString() },
+    {
+      label: "Dernier rapport",
+      value: lastReportDate ? lastReportFormatter.format(lastReportDate) : "—",
+    },
+  ];
+
+  const content =
+    role === "SCOUT" ? (
+      <ScoutDashboard reports={recentReports} />
+    ) : (
+      <CollaborativeDashboard reports={recentReports} />
+    );
 
   return (
-    <div>
-      {role === "SCOUT" && <ScoutDashboard />}
-      {(role === "RECRUITER" || role === "AGENT") && <RecruiterAgentDashboard />}
-      {role === "ADMIN" && <div>Admin Dashboard</div>}
+    <div className="space-y-8">
+      <DashboardHero
+        name={displayName}
+        roleLabel={roleLabels[role]}
+        metrics={metrics}
+      />
+      {content}
+      {role === "ADMIN" && (
+        <div className="rounded-2xl border border-dashed border-white/20 bg-slate-900/40 p-6 text-sm text-slate-300">
+          Des widgets spécifiques à l’administration seront prochainement disponibles.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+/**
+ * @page PlayersPage
+ * @description Liste des joueurs enregistrés dans la base.
+ */
+export default async function PlayersPage() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const players = await prisma.player.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { reports: true } },
+    },
+  });
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-slate-400">Base joueurs Statisfoot</p>
+          <h1 className="text-3xl font-bold text-white">Joueurs</h1>
+        </div>
+        <p className="text-sm text-slate-400">
+          {players.length} joueur{players.length > 1 ? "s" : ""} suivi{players.length > 1 ? "s" : ""}.
+        </p>
+      </header>
+
+      <div className="overflow-x-auto rounded-2xl bg-slate-900/50 ring-1 ring-white/10">
+        <table className="w-full text-left text-sm text-slate-300">
+          <thead className="bg-slate-900/30 text-xs uppercase text-slate-400">
+            <tr>
+              <th scope="col" className="px-6 py-3">
+                Joueur
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Poste
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Rapports
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Ajouté le
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((player) => (
+              <tr
+                key={player.id}
+                className="border-b border-slate-800/60 hover:bg-slate-800/40"
+              >
+                <th scope="row" className="px-6 py-4 font-medium text-white">
+                  <Link
+                    href={`/players/${player.id}`}
+                    className="hover:text-accent"
+                  >
+                    {player.name}
+                  </Link>
+                  <span className="block text-xs text-slate-400">ID {player.id}</span>
+                </th>
+                <td className="px-6 py-4 capitalize">{player.position.toLowerCase()}</td>
+                <td className="px-6 py-4 text-sm">{player._count.reports}</td>
+                <td className="px-6 py-4 text-sm">
+                  {dateFormatter.format(player.createdAt)}
+                </td>
+              </tr>
+            ))}
+            {players.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-6 py-10 text-center text-sm text-slate-400">
+                  Aucun joueur enregistré pour le moment.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+interface ReportPageProps {
+  params: { id: string };
+}
+
+/**
+ * @page ReportDetailPage
+ * @description Visualisation détaillée d'un rapport.
+ */
+export default async function ReportDetailPage({ params }: ReportPageProps) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const report = await prisma.report.findUnique({
+    where: { id: params.id },
+    include: {
+      player: { select: { id: true, name: true, position: true } },
+      author: {
+        select: {
+          id: true,
+          firstname: true,
+          lastname: true,
+          email: true,
+        },
+      },
+    },
+  });
+
+  if (!report) {
+    notFound();
+  }
+
+  const isOwner = report.authorId === session.user.id;
+  const isAdmin = session.user.role === "ADMIN";
+
+  if (!isOwner && !isAdmin) {
+    notFound();
+  }
+
+  const authorName =
+    [report.author?.firstname, report.author?.lastname].filter(Boolean).join(" ") ||
+    report.author?.email ||
+    "Auteur inconnu";
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-slate-400">Rapport sur {report.player.name}</p>
+          <h1 className="text-3xl font-bold text-white">Rapport #{report.id}</h1>
+        </div>
+        <Link
+          href="/reports"
+          className="inline-flex items-center justify-center rounded-full bg-slate-900/60 px-4 py-2 text-sm font-semibold text-slate-200 ring-1 ring-white/10 hover:bg-slate-900"
+        >
+          Retour à la liste
+        </Link>
+      </div>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <div className="rounded-2xl bg-slate-900/50 p-6 ring-1 ring-white/10 lg:col-span-2">
+          <h2 className="text-lg font-semibold text-white">Observations</h2>
+          <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-slate-200">
+            {report.content}
+          </p>
+        </div>
+        <aside className="space-y-4 rounded-2xl bg-slate-900/40 p-6 ring-1 ring-white/10">
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Joueur
+            </h3>
+            <p className="mt-2 text-lg font-semibold text-white">{report.player.name}</p>
+            <p className="text-sm text-slate-300">
+              Poste&nbsp;: {report.player.position.toLowerCase()}
+            </p>
+            <p className="text-xs text-slate-500">ID {report.player.id}</p>
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Informations
+            </h3>
+            <dl className="mt-2 space-y-2 text-sm text-slate-300">
+              <div className="flex justify-between">
+                <dt>Statut</dt>
+                <dd className="capitalize">{report.status.toLowerCase()}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Créé le</dt>
+                <dd>{dateFormatter.format(report.createdAt)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Auteur</dt>
+                <dd className="text-right">{authorName}</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+});
+
+/**
+ * @page ReportsPage
+ * @description Liste des rapports créés par l'utilisateur connecté.
+ */
+export default async function ReportsPage() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const reports = await prisma.report.findMany({
+    where: { authorId: session.user.id },
+    include: {
+      player: { select: { id: true, name: true, position: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-slate-400">Historique de vos observations</p>
+          <h1 className="text-3xl font-bold text-white">Mes rapports</h1>
+        </div>
+        <Link
+          href="/reports/new"
+          className="inline-flex items-center justify-center rounded-full bg-accent px-4 py-2 text-sm font-semibold text-dark-start hover:bg-accent/90"
+        >
+          Nouveau rapport
+        </Link>
+      </header>
+
+      <div className="overflow-x-auto rounded-2xl bg-slate-900/50 ring-1 ring-white/10">
+        <table className="w-full text-left text-sm text-slate-300">
+          <thead className="bg-slate-900/30 text-xs uppercase text-slate-400">
+            <tr>
+              <th scope="col" className="px-6 py-3">
+                Joueur
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Poste
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Statut
+              </th>
+              <th scope="col" className="px-6 py-3">
+                Créé le
+              </th>
+              <th scope="col" className="px-6 py-3">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {reports.map((report) => (
+              <tr
+                key={report.id}
+                className="border-b border-slate-800/60 hover:bg-slate-800/40"
+              >
+                <th scope="row" className="px-6 py-4 font-medium text-white">
+                  <span className="block text-sm">{report.player.name}</span>
+                  <span className="block text-xs text-slate-400">ID {report.player.id}</span>
+                </th>
+                <td className="px-6 py-4 capitalize">{report.player.position.toLowerCase()}</td>
+                <td className="px-6 py-4 text-sm capitalize">{report.status.toLowerCase()}</td>
+                <td className="px-6 py-4 text-sm">{dateFormatter.format(report.createdAt)}</td>
+                <td className="px-6 py-4 text-right text-sm">
+                  <Link href={`/reports/${report.id}`} className="text-accent hover:text-accent/80">
+                    Consulter
+                  </Link>
+                </td>
+              </tr>
+            ))}
+            {reports.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-6 py-10 text-center text-sm text-slate-400">
+                  Aucun rapport disponible pour le moment.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
 
 /**
@@ -54,18 +55,18 @@ export function Navbar() {
         {/* Navigation desktop */}
         <nav className="hidden md:flex items-center gap-6 text-sm">
           {session && (
-            <a
+            <Link
               href="/reports/new"
               className="hover:text-primary text-slate-600"
             >
               Nouveau rapport
-            </a>
+            </Link>
           )}
           {session ? (
             <>
-              <a href="/profile" className="hover:text-primary text-slate-600">
+              <Link href="/profile" className="hover:text-primary text-slate-600">
                 Mon profil
-              </a>
+              </Link>
               <button
                 onClick={() => signOut()}
                 className="inline-flex items-center rounded-full bg-accent text-primary font-semibold px-4 py-2"
@@ -74,12 +75,12 @@ export function Navbar() {
               </button>
             </>
           ) : (
-            <a
+            <Link
               href="/login"
               className="inline-flex items-center rounded-full bg-accent text-primary font-semibold px-4 py-2"
             >
               Connexion
-            </a>
+            </Link>
           )}
         </nav>
       </div>
@@ -89,18 +90,18 @@ export function Navbar() {
         <div className="md:hidden border-t border-slate-200 bg-white">
           <nav className="px-4 py-4 flex flex-col gap-4 text-sm">
             {session && (
-              <a
+              <Link
                 href="/reports/new"
                 className="hover:text-primary text-slate-700"
               >
                 Nouveau rapport
-              </a>
+              </Link>
             )}
             {session ? (
               <>
-                <a href="/profile" className="hover:text-primary text-slate-700">
+                <Link href="/profile" className="hover:text-primary text-slate-700">
                   Mon profil
-                </a>
+                </Link>
                 <button
                   onClick={() => signOut()}
                   className="inline-flex justify-center items-center rounded-full bg-accent text-primary font-semibold px-4 py-2"
@@ -109,12 +110,12 @@ export function Navbar() {
                 </button>
               </>
             ) : (
-              <a
+              <Link
                 href="/login"
                 className="inline-flex justify-center items-center rounded-full bg-accent text-primary font-semibold px-4 py-2"
               >
                 Connexion
-              </a>
+              </Link>
             )}
           </nav>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,13 +4,9 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 
 const navItems = [
-  "Tableau de bord",
-  "Joueurs",
-  "Rapports",
-  "Demandes",
-  "Favoris",
-  "Facturation",
-  "Paramètres",
+  { label: "Tableau de bord", href: "/dashboard" },
+  { label: "Joueurs", href: "/players" },
+  { label: "Rapports", href: "/reports" },
 ];
 
 /**
@@ -21,6 +17,13 @@ const navItems = [
  */
 export function Sidebar() {
   const { data: session } = useSession();
+  const fullName = session?.user
+    ? ([session.user.firstname, session.user.lastname].filter(Boolean).join(" ") ||
+        session.user.name ||
+        session.user.email ||
+        "Mon compte")
+    : "";
+  const initials = fullName ? fullName.charAt(0).toUpperCase() : "U";
 
   return (
     <aside className="w-[280px] bg-dark-start/50 p-6 flex flex-col">
@@ -37,11 +40,11 @@ export function Sidebar() {
       <nav className="flex flex-col gap-2">
         {navItems.map((item) => (
           <Link
-            key={item}
-            href="#"
-            className="px-3 py-2 rounded-md text-sm font-medium text-slate-300 hover:bg-accent/10 hover:text-white"
+            key={item.href}
+            href={item.href}
+            className="px-3 py-2 rounded-md text-sm font-medium text-slate-300 transition hover:bg-accent/10 hover:text-white"
           >
-            {item}
+            {item.label}
           </Link>
         ))}
       </nav>
@@ -49,11 +52,11 @@ export function Sidebar() {
         {session && (
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-full bg-accent flex items-center justify-center text-dark-start font-bold">
-              {session.user.name?.charAt(0).toUpperCase()}
+              {initials}
             </div>
             <div>
-              <p className="font-semibold text-white">{session.user.name}</p>
-              <p className="text-xs text-slate-400">{session.user.role}</p>
+              <p className="font-semibold text-white">{fullName}</p>
+              <p className="text-xs uppercase text-slate-400">{session.user.role}</p>
             </div>
           </div>
         )}

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useTransition } from "react";
+import { signOut } from "next-auth/react";
+
+type LogoutButtonProps = {
+  /**
+   * Classes supplémentaires à appliquer au bouton.
+   */
+  className?: string;
+  /**
+   * Variante visuelle du bouton.
+   */
+  variant?: "solid" | "ghost";
+};
+
+/**
+ * @component LogoutButton
+ * @description Bouton permettant de mettre fin à la session utilisateur depuis un composant client.
+ */
+export function LogoutButton({
+  className = "",
+  variant = "solid",
+}: LogoutButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(() => {
+      void signOut();
+    });
+  }
+
+  const baseClasses =
+    "inline-flex items-center justify-center rounded-full text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent";
+  const variantClasses =
+    variant === "ghost"
+      ? "text-slate-300 hover:text-white hover:bg-white/10 focus:ring-offset-dark-end"
+      : "bg-accent text-dark-start hover:bg-accent/90 focus:ring-offset-dark-end";
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending}
+      className={`${baseClasses} ${variantClasses} px-4 py-2 disabled:cursor-not-allowed disabled:opacity-70 ${className}`.trim()}
+    >
+      {isPending ? "Déconnexion…" : "Déconnexion"}
+    </button>
+  );
+}
+

--- a/src/components/dashboard/MyReports.tsx
+++ b/src/components/dashboard/MyReports.tsx
@@ -1,48 +1,157 @@
-const reports = [
-  { id: 1, status: "Publié", date: "2023-10-26", player: "Kylian Mbappé", club: "PSG" },
-  { id: 2, status: "En revue", date: "2023-10-24", player: "Lamine Yamal", club: "FC Barcelona" },
-  { id: 3, status: "Brouillon", date: "2023-10-22", player: "Warren Zaïre-Emery", club: "PSG" },
-  { id: 4, status: "Rejeté", date: "2023-10-21", player: "Jude Bellingham", club: "Real Madrid" },
-];
+import Link from "next/link";
+
+export type DashboardReport = {
+  id: string;
+  status: string;
+  createdAt: Date;
+  content: string;
+  player: {
+    id: string;
+    name: string;
+    position: string;
+  };
+};
+
+const statusLabels: Record<string, string> = {
+  draft: "Brouillon",
+  published: "Publié",
+  review: "En revue",
+};
+
+const statusStyles: Record<string, string> = {
+  draft: "bg-slate-800 text-slate-300",
+  published: "bg-emerald-500/10 text-emerald-300",
+  review: "bg-amber-500/10 text-amber-300",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+function formatStatus(status: string) {
+  const normalized = status.toLowerCase();
+  return statusLabels[normalized] ?? status;
+}
+
+function getStatusClassName(status: string) {
+  const normalized = status.toLowerCase();
+  return (
+    statusStyles[normalized] ?? "bg-slate-800 text-slate-200"
+  );
+}
+
+function formatExcerpt(content: string) {
+  if (content.length <= 80) {
+    return content;
+  }
+  return `${content.slice(0, 77)}…`;
+}
+
+interface MyReportsProps {
+  reports: DashboardReport[];
+}
 
 /**
  * @component MyReports
  * @description Affiche un tableau des rapports de l'utilisateur sur le tableau de bord.
- * Les données sont actuellement statiques mais sont destinées à être remplacées par des données dynamiques.
+ * @param {MyReportsProps} props - Les propriétés du composant.
  * @returns {JSX.Element} Le composant du tableau des rapports.
  */
-export function MyReports() {
+export function MyReports({ reports }: MyReportsProps) {
   return (
-    <div className="bg-slate-900/50 rounded-2xl ring-1 ring-white/10 shadow-md p-6">
-      <h3 className="text-white font-semibold mb-4">Mes rapports</h3>
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm text-left text-slate-300">
-          <thead className="text-xs text-slate-400 uppercase bg-slate-900/30">
-            <tr>
-              <th scope="col" className="px-6 py-3">Joueur</th>
-              <th scope="col" className="px-6 py-3">Club</th>
-              <th scope="col" className="px-6 py-3">Date</th>
-              <th scope="col" className="px-6 py-3">Statut</th>
-              <th scope="col" className="px-6 py-3"><span className="sr-only">Actions</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            {reports.map((report) => (
-              <tr key={report.id} className="border-b border-slate-800 hover:bg-slate-800/40">
-                <th scope="row" className="px-6 py-4 font-medium text-white whitespace-nowrap">{report.player}</th>
-                <td className="px-6 py-4">{report.club}</td>
-                <td className="px-6 py-4">{report.date}</td>
-                <td className="px-6 py-4">
-                  {/* Status badge would go here */}
-                  <span>{report.status}</span>
-                </td>
-                <td className="px-6 py-4 text-right">
-                  <a href="#" className="font-medium text-accent hover:underline">Éditer</a>
-                </td>
+    <div className="rounded-2xl bg-slate-900/50 p-6 shadow-md ring-1 ring-white/10">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-white font-semibold">Mes rapports récents</h3>
+        <Link
+          href="/reports"
+          className="text-xs font-medium text-accent hover:text-accent/80"
+        >
+          Voir tous les rapports
+        </Link>
+      </div>
+      <div className="mt-4 overflow-x-auto">
+        {reports.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/10 bg-slate-900/40 p-10 text-center">
+            <p className="text-sm text-slate-300">
+              Aucun rapport enregistré pour le moment.
+            </p>
+            <Link
+              href="/reports/new"
+              className="inline-flex items-center justify-center rounded-full bg-accent px-4 py-2 text-sm font-semibold text-dark-start hover:bg-accent/90"
+            >
+              Rédiger mon premier rapport
+            </Link>
+          </div>
+        ) : (
+          <table className="w-full text-left text-sm text-slate-300">
+            <thead className="bg-slate-900/30 text-xs uppercase text-slate-400">
+              <tr>
+                <th scope="col" className="px-6 py-3">
+                  Joueur
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Poste
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Extrait
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Date
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  Statut
+                </th>
+                <th scope="col" className="px-6 py-3">
+                  <span className="sr-only">Actions</span>
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {reports.map((report) => (
+                <tr
+                  key={report.id}
+                  className="border-b border-slate-800/60 hover:bg-slate-800/40"
+                >
+                  <th
+                    scope="row"
+                    className="px-6 py-4 font-medium text-white"
+                  >
+                    <span className="block text-sm">{report.player.name}</span>
+                    <span className="text-xs text-slate-400">
+                      ID {report.player.id}
+                    </span>
+                  </th>
+                  <td className="px-6 py-4 text-sm capitalize">
+                    {report.player.position.toLowerCase()}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-slate-400">
+                    {formatExcerpt(report.content)}
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    {dateFormatter.format(report.createdAt)}
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    <span
+                      className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold ${getStatusClassName(report.status)}`.trim()}
+                    >
+                      {formatStatus(report.status)}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-right text-sm">
+                    <Link
+                      href={`/reports/${report.id}`}
+                      className="font-medium text-accent hover:text-accent/80"
+                    >
+                      Consulter
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/QuickActions.tsx
+++ b/src/components/dashboard/QuickActions.tsx
@@ -1,9 +1,21 @@
 import Link from "next/link";
 
 const actions = [
-  { label: "Nouveau rapport", href: "/reports/new" },
-  { label: "Répondre à une demande", href: "#" },
-  { label: "Importer une vidéo", href: "#" },
+  {
+    label: "Nouveau rapport",
+    description: "Consigner une nouvelle observation terrain",
+    href: "/reports/new",
+  },
+  {
+    label: "Joueurs",
+    description: "Explorer la base de joueurs existants",
+    href: "/players",
+  },
+  {
+    label: "Rapports",
+    description: "Revoir l'ensemble de vos rapports sauvegardés",
+    href: "/reports",
+  },
 ];
 
 /**
@@ -20,9 +32,10 @@ export function QuickActions() {
           <Link
             key={action.label}
             href={action.href}
-            className="w-full text-center px-4 py-2 bg-accent text-dark-start font-semibold rounded-lg hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-dark-end focus:ring-accent"
+            className="w-full rounded-xl border border-white/10 bg-slate-900/60 px-4 py-3 text-left transition hover:border-accent/50 hover:bg-slate-900 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-dark-end"
           >
-            {action.label}
+            <span className="block text-sm font-semibold text-white">{action.label}</span>
+            <span className="mt-1 block text-xs text-slate-400">{action.description}</span>
           </Link>
         ))}
       </div>

--- a/src/components/reports/NewReportForm.tsx
+++ b/src/components/reports/NewReportForm.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+type PlayerOption = {
+  id: string;
+  name: string;
+  position: string;
+};
+
+interface NewReportFormProps {
+  players: PlayerOption[];
+}
+
+type FeedbackState = {
+  type: "success" | "error";
+  message: string;
+} | null;
+
+/**
+ * @component NewReportForm
+ * @description Formulaire client permettant de créer un rapport scout.
+ */
+export function NewReportForm({ players }: NewReportFormProps) {
+  const router = useRouter();
+  const [playerId, setPlayerId] = useState(players[0]?.id ?? "");
+  const [status, setStatus] = useState("draft");
+  const [content, setContent] = useState("");
+  const [feedback, setFeedback] = useState<FeedbackState>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isDisabled = players.length === 0 || isPending;
+
+  function resetForm() {
+    setContent("");
+    setStatus("draft");
+    setFeedback({ type: "success", message: "Rapport sauvegardé avec succès." });
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFeedback(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/reports", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ playerId, content, status }),
+        });
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload.error ?? "Impossible d'enregistrer le rapport.");
+        }
+
+        resetForm();
+        router.refresh();
+      } catch (error) {
+        setFeedback({
+          type: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Une erreur inattendue est survenue.",
+        });
+      }
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-6 rounded-2xl bg-slate-900/50 p-8 ring-1 ring-white/10"
+    >
+      <div className="grid gap-6 md:grid-cols-2">
+        <label className="flex flex-col gap-2 text-sm text-slate-200">
+          Joueur observé
+          <select
+            value={playerId}
+            onChange={(event) => setPlayerId(event.target.value)}
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+            disabled={players.length === 0}
+          >
+            {players.map((player) => (
+              <option key={player.id} value={player.id}>
+                {player.name} · {player.position.toLowerCase()}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-200">
+          Statut
+          <select
+            value={status}
+            onChange={(event) => setStatus(event.target.value)}
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            <option value="draft">Brouillon</option>
+            <option value="review">À relire</option>
+            <option value="published">Publié</option>
+          </select>
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-2 text-sm text-slate-200">
+        Contenu du rapport
+        <textarea
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          placeholder="Consignez ici vos observations détaillées, les axes de progression et les recommandations."
+          minLength={20}
+          rows={8}
+          className="resize-y rounded-lg border border-white/10 bg-slate-950/60 px-3 py-3 text-sm leading-6 text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          required
+        />
+      </label>
+
+      {feedback && (
+        <div
+          role="alert"
+          className={`rounded-xl border px-4 py-3 text-sm ${
+            feedback.type === "success"
+              ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+              : "border-rose-500/40 bg-rose-500/10 text-rose-200"
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      {players.length === 0 && (
+        <p className="text-sm text-rose-200">
+          Aucun joueur n’est disponible pour le moment. Ajoutez d’abord des joueurs
+          avant de créer un rapport.
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button
+          type="submit"
+          disabled={isDisabled}
+          className="inline-flex items-center justify-center rounded-full bg-accent px-6 py-2 text-sm font-semibold text-dark-start transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isPending ? "Enregistrement…" : "Enregistrer le rapport"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setContent("")}
+          className="text-sm font-medium text-slate-400 hover:text-white"
+        >
+          Effacer le contenu
+        </button>
+      </div>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a metrics hero and logout button to the dashboard and drive its widgets from live Prisma data
- refresh quick actions and reports table to use real database records with navigation to detailed report views
- add players/reports listing pages, a reusable logout button, and an improved report creation form that posts to a hardened API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f93addf083339099be6e2b274de1