### PR TITLE
Harden report submission permissions

### DIFF
--- a/src/app/api/reports/[id]/submit/route.ts
+++ b/src/app/api/reports/[id]/submit/route.ts
@@ -1,20 +1,57 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { PrismaClient } from "@prisma/client";
+import type { Role } from "@prisma/client";
 
-const prisma = new PrismaClient();
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { hasPermission, PERMISSIONS } from "@/lib/rbac";
 
 // POST /api/reports/:id/submit -> submit a report
 export async function POST(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const session = await auth();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  const report = await prisma.report.update({
+  const existingReport = await prisma.report.findUnique({
     where: { id: params.id },
-    data: { status: "submitted" },
+    select: { id: true, authorId: true },
   });
-  return NextResponse.json(report);
+
+  if (!existingReport) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  const role = session.user.role as Role | undefined;
+  const canUpdate =
+    existingReport.authorId === session.user.id ||
+    (role ? hasPermission(role, PERMISSIONS["reports:update"]) : false);
+
+  if (!canUpdate) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const updatedReport = await prisma.report.update({
+    where: { id: params.id },
+    data: { status: "published" },
+    select: {
+      id: true,
+      title: true,
+      content: true,
+      status: true,
+      rating: true,
+      strengths: true,
+      weaknesses: true,
+      recommendation: true,
+      matchDate: true,
+      createdAt: true,
+      player: {
+        select: { id: true, name: true, position: true },
+      },
+    },
+  });
+
+  return NextResponse.json({ report: updatedReport });
 }


### PR DESCRIPTION
## Summary
- reuse the shared Prisma client for the report submission API route
- enforce authenticated user ownership or update permission before publishing
- return a sanitized payload after updating the report status to published

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c0457fe883338f1478b6fb961bae