### PR TITLE
Add secure player creation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+dist-test/

--- a/src/app/players/new/NewPlayerForm.tsx
+++ b/src/app/players/new/NewPlayerForm.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  createPlayerSchema,
+  normalizePlayerInput,
+  type CreatePlayerInput,
+} from "@/lib/players";
+
+type FeedbackState =
+  | { type: "success" | "error"; message: string }
+  | null;
+
+type ServerFieldErrors = Record<string, string[]>;
+
+const positionPlaceholders = [
+  "Gardien de but",
+  "Défenseur central",
+  "Latéral gauche",
+  "Milieu défensif",
+  "Ailier droit",
+  "Attaquant de pointe",
+];
+
+function pickPlaceholder(index: number) {
+  return positionPlaceholders[index % positionPlaceholders.length] ?? "Poste principal";
+}
+
+export function NewPlayerForm() {
+  const router = useRouter();
+  const [feedback, setFeedback] = useState<FeedbackState>(null);
+  const [serverFieldErrors, setServerFieldErrors] = useState<ServerFieldErrors | null>(null);
+  const [createdPlayerId, setCreatedPlayerId] = useState<string | null>(null);
+
+  const placeholder = useMemo(() => pickPlaceholder(Date.now()), []);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<CreatePlayerInput>({
+    resolver: zodResolver(createPlayerSchema),
+    defaultValues: { name: "", position: "" },
+  });
+
+  const onSubmit = async (values: CreatePlayerInput) => {
+    setFeedback(null);
+    setServerFieldErrors(null);
+    setCreatedPlayerId(null);
+
+    const payload = normalizePlayerInput(values);
+
+    try {
+      const response = await fetch("/api/players", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const content = await response.json().catch(() => ({}));
+        if (content?.fieldErrors && typeof content.fieldErrors === "object") {
+          setServerFieldErrors(content.fieldErrors as ServerFieldErrors);
+        }
+        const message =
+          typeof content?.error === "string"
+            ? content.error
+            : "Impossible d'enregistrer ce joueur.";
+        setFeedback({ type: "error", message });
+        return;
+      }
+
+      const player = (await response.json()) as { id: string; name: string };
+      setFeedback({ type: "success", message: "Le joueur a été ajouté avec succès." });
+      setCreatedPlayerId(player.id);
+      reset({ name: "", position: "" });
+      router.refresh();
+    } catch (error) {
+      setFeedback({
+        type: "error",
+        message: "Une erreur inattendue est survenue lors de l'enregistrement.",
+      });
+    }
+  };
+
+  const nameError = errors.name?.message;
+  const positionError = errors.position?.message;
+
+  const serverNameError = serverFieldErrors?.name?.[0];
+  const serverPositionError = serverFieldErrors?.position?.[0];
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6 rounded-2xl bg-slate-900/50 p-8 shadow-lg ring-1 ring-white/10"
+    >
+      <div className="grid gap-6 md:grid-cols-2">
+        <label className="flex flex-col gap-2 text-sm text-slate-200">
+          Nom complet du joueur
+          <input
+            {...register("name")}
+            type="text"
+            placeholder="Ex. Enzo Leclerc"
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          {(nameError || serverNameError) && (
+            <span className="text-xs text-rose-300">{nameError || serverNameError}</span>
+          )}
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-200">
+          Poste principal
+          <input
+            {...register("position")}
+            type="text"
+            placeholder={placeholder}
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          {(positionError || serverPositionError) && (
+            <span className="text-xs text-rose-300">{positionError || serverPositionError}</span>
+          )}
+        </label>
+      </div>
+
+      {feedback && (
+        <div
+          role="alert"
+          className={`rounded-xl border px-4 py-3 text-sm ${
+            feedback.type === "success"
+              ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+              : "border-rose-500/40 bg-rose-500/10 text-rose-200"
+          }`}
+        >
+          <p>{feedback.message}</p>
+          {feedback.type === "success" && createdPlayerId && (
+            <div className="mt-2 flex flex-wrap gap-3 text-xs">
+              <Link
+                href={`/players/${createdPlayerId}`}
+                className="font-semibold text-white underline-offset-4 hover:underline"
+              >
+                Consulter la fiche du joueur
+              </Link>
+              <Link
+                href="/players"
+                className="font-semibold text-white underline-offset-4 hover:underline"
+              >
+                Retour à la liste des joueurs
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center justify-center rounded-full bg-accent px-6 py-2 text-sm font-semibold text-dark-start transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isSubmitting ? "Enregistrement…" : "Ajouter le joueur"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            reset({ name: "", position: "" });
+            setServerFieldErrors(null);
+            setFeedback(null);
+            setCreatedPlayerId(null);
+          }}
+          className="text-sm font-medium text-slate-400 transition hover:text-white"
+        >
+          Réinitialiser
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/players/new/page.tsx
+++ b/src/app/players/new/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import type { Role } from "@prisma/client";
+
+import { auth } from "@/lib/auth";
+import { hasPermission, PERMISSIONS } from "@/lib/rbac";
+import { NewPlayerForm } from "./NewPlayerForm";
+
+/**
+ * @page NewPlayerPage
+ * @description Page de création d'un joueur.
+ */
+export default async function NewPlayerPage() {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const role = session.user.role as Role | undefined;
+  const canCreatePlayer = role
+    ? hasPermission(role, PERMISSIONS["players:create"])
+    : false;
+
+  if (!canCreatePlayer) {
+    redirect("/players");
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm text-slate-400">Créer un nouveau joueur</p>
+        <h1 className="text-3xl font-bold text-white">Ajouter un joueur</h1>
+        <p className="text-sm text-slate-400">
+          Renseignez les informations de base du joueur pour l'ajouter à votre base
+          Statisfoot. Vous pourrez enrichir sa fiche avec des rapports et des
+          évaluations par la suite.
+        </p>
+      </header>
+
+      <NewPlayerForm />
+    </div>
+  );
+}

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -1,0 +1,37 @@
+import { z, type infer as zInfer } from "./zod";
+
+const NAME_MAX_LENGTH = 120;
+const POSITION_MAX_LENGTH = 80;
+const MIN_NAME_LENGTH = 3;
+const MIN_POSITION_LENGTH = 2;
+
+function hasMinimumLength(value: string, minimum: number) {
+  return value.trim().length >= minimum;
+}
+
+export const createPlayerSchema = z.object({
+  name: z
+    .string()
+    .max(NAME_MAX_LENGTH, `Le nom ne peut pas dépasser ${NAME_MAX_LENGTH} caractères.`)
+    .refine(
+      (value) => hasMinimumLength(value, MIN_NAME_LENGTH),
+      `Le nom doit contenir au moins ${MIN_NAME_LENGTH} caractères.`
+    ),
+  position: z
+    .string()
+    .max(POSITION_MAX_LENGTH, `Le poste ne peut pas dépasser ${POSITION_MAX_LENGTH} caractères.`)
+    .refine(
+      (value) => hasMinimumLength(value, MIN_POSITION_LENGTH),
+      `Le poste doit contenir au moins ${MIN_POSITION_LENGTH} caractères.`
+    ),
+});
+
+export type CreatePlayerInput = zInfer<typeof createPlayerSchema>;
+
+export function normalizePlayerInput(values: CreatePlayerInput) {
+  const normalize = (value: string) => value.trim().replace(/\s+/g, " ");
+  return {
+    name: normalize(values.name),
+    position: normalize(values.position),
+  } satisfies CreatePlayerInput;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,6 +49,10 @@ export const ROUTE_RULES: RouteRule[] = [
     permission: PERMISSIONS["admin:access"],
   },
   {
+    matcher: (path) => path === "/players/new" || path.startsWith("/players/new/"),
+    permission: PERMISSIONS["players:create"],
+  },
+  {
     matcher: (path) => path.startsWith("/players"),
     permission: PERMISSIONS["players:read"],
   },

--- a/tests/middleware.spec.ts
+++ b/tests/middleware.spec.ts
@@ -31,6 +31,27 @@ const tests: TestCase[] = [
       assert.ok(!isAuthorized(scoutRole, "/reports"));
     },
   },
+  {
+    name: "/players/new requires players:create permission",
+    run: () => {
+      const permission = resolveRequiredPermission("/players/new");
+      assert.equal(permission, PERMISSIONS["players:create"]);
+    },
+  },
+  {
+    name: "recruiter can access /players/new",
+    run: () => {
+      const recruiterRole = ROLES.RECRUITER;
+      assert.ok(isAuthorized(recruiterRole, "/players/new"));
+    },
+  },
+  {
+    name: "scout cannot access /players/new",
+    run: () => {
+      const scoutRole = ROLES.SCOUT;
+      assert.ok(!isAuthorized(scoutRole, "/players/new"));
+    },
+  },
 ];
 
 void runTests(tests);


### PR DESCRIPTION
## Summary
- enforce authentication and validation on the players API using a shared schema
- add a dedicated player creation page and refresh the list/detail views to reflect live data
- update middleware grants and unit tests to cover the new player creation permission

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d94ef4008333b6aa62544a34dbdb