### PR TITLE
Fix player creation server action exports and API validation

### DIFF
--- a/src/app/players/CreatePlayerForm.tsx
+++ b/src/app/players/CreatePlayerForm.tsx
@@ -2,11 +2,11 @@
 
 import { useActionState, useEffect, useRef } from "react";
 
+import { createPlayer } from "@/app/players/actions";
 import {
-  createPlayer,
   initialCreatePlayerState,
   type CreatePlayerState,
-} from "@/app/players/actions";
+} from "@/app/players/state";
 
 export function CreatePlayerForm() {
   const formRef = useRef<HTMLFormElement>(null);

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -2,14 +2,9 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import type { Role } from "@prisma/client";
 
-
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { hasPermission, PERMISSIONS } from "@/lib/rbac";
-
-import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-import { hasPermission, ROLES } from "@/lib/rbac";
+import { hasPermission, PERMISSIONS, ROLES } from "@/lib/rbac";
 
 import CreatePlayerForm from "./CreatePlayerForm";
 
@@ -32,16 +27,13 @@ export default async function PlayersPage() {
     redirect("/login");
   }
 
-  const role = session.user.role as Role | undefined;
-  const canCreatePlayer = role
-    ? hasPermission(role, PERMISSIONS["players:create"])
-    : false;
-
   const role =
     session.user.role && ROLE_VALUES.includes(session.user.role as Role)
       ? (session.user.role as Role)
       : undefined;
-  const canCreatePlayer = role ? hasPermission(role, "players:create") : false;
+  const canCreatePlayer = role
+    ? hasPermission(role, PERMISSIONS["players:create"])
+    : false;
 
 
   const players = await prisma.player.findMany({

--- a/src/app/players/state.ts
+++ b/src/app/players/state.ts
@@ -1,0 +1,13 @@
+import type { CreatePlayerInput } from "@/lib/players";
+
+export type CreatePlayerState = {
+  success: boolean;
+  errors: Partial<Record<keyof CreatePlayerInput, string>>;
+  message: string | null;
+};
+
+export const initialCreatePlayerState: CreatePlayerState = {
+  success: false,
+  errors: {},
+  message: null,
+};


### PR DESCRIPTION
## Summary
- move the player creation form state into its own module so the server action file only exports async functions
- reuse the shared player schema utilities in the server action and persistence helper
- repair the /api/players route authorization and validation flow while normalizing stored data

## Testing
- npm run lint *(fails: requires @eslint/eslintrc package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e1af0b188333904c83c4f6f36c4d