### PR TITLE
Align report API with Prisma schema

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,75 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
- test
-import { auth } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-
-// GET /api/reports -> liste des rapports de l'utilisateur authentifié
-export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const reports = await prisma.report.findMany({
-    where: { authorId: session.user.id },
-    include: {
-      player: {
-        select: { id: true, name: true, position: true },
-      },
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  return NextResponse.json(reports);
-}
-
-// POST /api/reports -> créer un nouveau rapport
-export async function POST(req: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const body = await req.json();
-  const playerId = body?.playerId as string | undefined;
-  const content = body?.content as string | undefined;
-  const status = body?.status as string | undefined;
-
-  if (!playerId || !content) {
-    return NextResponse.json(
-      { error: "Les champs 'playerId' et 'content' sont obligatoires." },
-      { status: 400 },
-    );
-  }
-
-  const player = await prisma.player.findUnique({
-    where: { id: playerId },
-    select: { id: true },
-  });
-
-  if (!player) {
-    return NextResponse.json(
-      { error: "Le joueur sélectionné est introuvable." },
-      { status: 400 },
-    );
-  }
-
-  const report = await prisma.report.create({
-    data: {
-      authorId: session.user.id,
-      playerId,
-      content,
-      status: status && status.length > 0 ? status : undefined,
-    },
-    include: {
-      player: {
-        select: { id: true, name: true, position: true },
-      },
-    },
-  });
-
-  return NextResponse.json(report, { status: 201 });
-
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -95,6 +24,13 @@ type ValidationResult =
 
 const TITLE_MAX_LENGTH = 255;
 const TEXTAREA_MAX_LENGTH = 5000;
+
+const PLAYER_SELECT = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  primaryPosition: true,
+} as const;
 
 function validateCreateReportPayload(body: unknown): ValidationResult {
   if (!body || typeof body !== "object") {
@@ -144,7 +80,7 @@ function validateCreateReportPayload(body: unknown): ValidationResult {
     }
   }
 
-  const mapOptionalTextField = (field: string, value: unknown) => {
+  const mapOptionalTextField = (field: "strengths" | "weaknesses" | "recommendation", value: unknown) => {
     if (value === undefined || value === null) return;
 
     if (typeof value !== "string") {
@@ -184,8 +120,26 @@ function validateCreateReportPayload(body: unknown): ValidationResult {
 
   return { success: true, data: data as CreateReportPayload };
 }
- 
-// GET /api/reports -> list reports for the authenticated user
+
+function serializePlayer(player: {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  primaryPosition: string | null;
+}) {
+  const fullName = [player.firstName, player.lastName]
+    .filter((value) => value && value.trim().length > 0)
+    .join(" ");
+
+  return {
+    id: player.id,
+    firstName: player.firstName,
+    lastName: player.lastName,
+    primaryPosition: player.primaryPosition,
+    displayName: fullName.length > 0 ? fullName : player.id,
+  };
+}
+
 export async function GET() {
   const session = await auth();
   if (!session?.user?.id)
@@ -194,15 +148,24 @@ export async function GET() {
   try {
     const reports = await prisma.report.findMany({
       where: { authorId: session.user.id },
+      include: {
+        player: { select: PLAYER_SELECT },
+      },
+      orderBy: { createdAt: "desc" },
     });
-    return NextResponse.json(reports);
+
+    const payload = reports.map((report) => ({
+      ...report,
+      player: serializePlayer(report.player),
+    }));
+
+    return NextResponse.json(payload);
   } catch (error) {
     console.error("[Reports] Failed to fetch reports", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
 
-// POST /api/reports  -> créer un rapport (draft)
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id)
@@ -225,20 +188,31 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { playerId, matchDate, ...rest } = validationResult.data;
+  const { playerId, title, content, rating, strengths, weaknesses, recommendation } =
+    validationResult.data;
 
   try {
-    const player = await prisma.player.findUnique({ where: { id: playerId } });
+    const player = await prisma.player.findUnique({
+      where: { id: playerId },
+      select: { id: true },
+    });
     if (!player) {
       return NextResponse.json({ error: "Player not found" }, { status: 404 });
     }
 
     const report = await prisma.report.create({
       data: {
-        ...rest,
-        matchDate: matchDate ?? undefined,
         authorId: session.user.id,
         playerId,
+        title,
+        summary: content,
+        strengths: strengths ?? undefined,
+        weaknesses: weaknesses ?? undefined,
+        potential: recommendation ?? undefined,
+        overall: rating ?? undefined,
+      },
+      include: {
+        player: { select: PLAYER_SELECT },
       },
     });
 
@@ -246,10 +220,12 @@ export async function POST(req: NextRequest) {
       `[Reports] Report ${report.id} created by ${session.user.id} for player ${playerId}`
     );
 
-    return NextResponse.json({ report }, { status: 201 });
+    return NextResponse.json(
+      { report: { ...report, player: serializePlayer(report.player) } },
+      { status: 201 }
+    );
   } catch (error) {
     console.error("[Reports] Failed to create report", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
-
 }

--- a/src/app/reports/new/NewReportPageClient.tsx
+++ b/src/app/reports/new/NewReportPageClient.tsx
@@ -10,7 +10,7 @@ import { RECOMMENDATIONS, reportSchema, submitReport, type ReportFormValues } fr
 type PlayerOption = {
   id: string;
   label: string;
-  position?: string;
+  primaryPosition?: string | null;
 };
 
 type ToastState = {
@@ -19,24 +19,39 @@ type ToastState = {
 };
 
 type NewReportPageClientProps = {
-  initialPlayers: { id: string; name: string | null; position: string | null }[];
+  initialPlayers: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    primaryPosition: string | null;
+  }[];
 };
 
 function formatPlayerLabel(player: any): string {
-  if (player?.name) return player.name;
-  const parts = [player?.firstname, player?.lastname].filter(Boolean);
-  if (parts.length > 0) return parts.join(" ");
-  if (player?.firstName || player?.lastName) {
-    return [player?.firstName, player?.lastName].filter(Boolean).join(" ");
+  const parts = [player?.firstName, player?.lastName].filter((value) => {
+    return typeof value === "string" && value.trim().length > 0;
+  });
+
+  if (parts.length > 0) {
+    return parts.join(" ");
   }
-  return player?.id ?? "Joueur";
+
+  if (typeof player?.name === "string" && player.name.trim().length > 0) {
+    return player.name;
+  }
+
+  if (typeof player?.id === "string" && player.id.trim().length > 0) {
+    return player.id;
+  }
+
+  return "Joueur";
 }
 
 function mapPlayersToOptions(payload: any[]): PlayerOption[] {
   return payload.map((player: any) => ({
     id: player.id,
     label: formatPlayerLabel(player),
-    position: player.position ?? player.role ?? undefined,
+    primaryPosition: player.primaryPosition ?? player.position ?? player.role ?? undefined,
   }));
 }
 
@@ -221,7 +236,9 @@ export function NewReportPageClient({ initialPlayers }: NewReportPageClientProps
                 {players.map((player) => (
                   <option key={player.id} value={player.id}>
                     {player.label}
-                    {player.position ? ` · ${player.position}` : ""}
+                    {player.primaryPosition
+                      ? ` · ${player.primaryPosition.toLowerCase()}`
+                      : ""}
                   </option>
                 ))}
               </select>

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -15,8 +15,16 @@ export default async function NewReportPage() {
   }
 
   const players = await prisma.player.findMany({
-    orderBy: { name: "asc" },
-    select: { id: true, name: true, position: true },
+    orderBy: [
+      { lastName: "asc" },
+      { firstName: "asc" },
+    ],
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      primaryPosition: true,
+    },
   });
 
   return <NewReportPageClient initialPlayers={players} />;

--- a/src/components/reports/NewReportForm.tsx
+++ b/src/components/reports/NewReportForm.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 
 type PlayerOption = {
   id: string;
-  name: string;
-  position: string;
+  displayName: string;
+  primaryPosition?: string | null;
 };
 
 interface NewReportFormProps {
@@ -85,7 +85,10 @@ export function NewReportForm({ players }: NewReportFormProps) {
           >
             {players.map((player) => (
               <option key={player.id} value={player.id}>
-                {player.name} · {player.position.toLowerCase()}
+                {player.displayName}
+                {player.primaryPosition
+                  ? ` · ${player.primaryPosition.toLowerCase()}`
+                  : ""}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- remove the duplicated report route handlers and rely on Prisma fields that exist on Player
- map incoming report payload fields to summary/overall/potential and normalize the serialized player payload
- update the new report page and client form to consume the revised player shape

## Testing
- npx prisma generate
- npm run lint -- --max-warnings=0 *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc248188008333b2e948ee2f0cd49f