### PR TITLE
Align player API and UI with split names and primary positions

### DIFF
--- a/src/app/players/CreatePlayerForm.tsx
+++ b/src/app/players/CreatePlayerForm.tsx
@@ -7,6 +7,10 @@ import {
   initialCreatePlayerState,
   type CreatePlayerState,
 } from "@/app/players/state";
+import {
+  POSITION_GROUP_VALUES,
+  formatPrimaryPosition,
+} from "@/lib/players";
 
 export function CreatePlayerForm() {
   const formRef = useRef<HTMLFormElement>(null);
@@ -29,39 +33,64 @@ export function CreatePlayerForm() {
     >
       <div className="space-y-1">
         <h2 className="text-lg font-semibold text-white">Ajouter un joueur</h2>
-        <p className="text-sm text-slate-400">
-          Renseignez le nom complet du joueur et son poste principal.
-        </p>
+          <p className="text-sm text-slate-400">
+            Renseignez le prénom, le nom de famille et sélectionnez le poste principal.
+          </p>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-3">
         <div className="flex flex-col gap-2">
-          <label htmlFor="name" className="text-sm text-slate-300">
-            Nom complet
+          <label htmlFor="firstName" className="text-sm text-slate-300">
+            Prénom
           </label>
           <input
-            id="name"
-            name="name"
+            id="firstName"
+            name="firstName"
             required
             className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-brand-sky focus:outline-none focus:ring-2 focus:ring-brand-sky"
           />
-          {state.errors.name && (
-            <p className="text-xs text-red-400">{state.errors.name}</p>
+          {state.errors.firstName && (
+            <p className="text-xs text-red-400">{state.errors.firstName}</p>
           )}
         </div>
 
         <div className="flex flex-col gap-2">
-          <label htmlFor="position" className="text-sm text-slate-300">
-            Poste principal
+          <label htmlFor="lastName" className="text-sm text-slate-300">
+            Nom
           </label>
           <input
-            id="position"
-            name="position"
+            id="lastName"
+            name="lastName"
             required
             className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-brand-sky focus:outline-none focus:ring-2 focus:ring-brand-sky"
           />
-          {state.errors.position && (
-            <p className="text-xs text-red-400">{state.errors.position}</p>
+          {state.errors.lastName && (
+            <p className="text-xs text-red-400">{state.errors.lastName}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label htmlFor="primaryPosition" className="text-sm text-slate-300">
+            Poste principal
+          </label>
+          <select
+            id="primaryPosition"
+            name="primaryPosition"
+            required
+            className="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-brand-sky focus:outline-none focus:ring-2 focus:ring-brand-sky"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Sélectionnez un poste
+            </option>
+            {POSITION_GROUP_VALUES.map((value) => (
+              <option key={value} value={value}>
+                {formatPrimaryPosition(value)} ({value})
+              </option>
+            ))}
+          </select>
+          {state.errors.primaryPosition && (
+            <p className="text-xs text-red-400">{state.errors.primaryPosition}</p>
           )}
         </div>
       </div>

--- a/src/app/players/[id]/page.tsx
+++ b/src/app/players/[id]/page.tsx
@@ -4,6 +4,7 @@ import type { Role } from "@prisma/client";
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatPlayerName, formatPrimaryPosition } from "@/lib/players";
 import { hasPermission, PERMISSIONS } from "@/lib/rbac";
 
 const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
@@ -91,6 +92,10 @@ export default async function PlayerProfile({
   }
 
   const creatorLabel = formatUserName(player.creator);
+  const playerFullName = formatPlayerName(player.firstName, player.lastName) || "Joueur";
+  const primaryPositionLabel = player.primaryPosition
+    ? formatPrimaryPosition(player.primaryPosition)
+    : "—";
 
   return (
     <div className="space-y-10">
@@ -100,9 +105,9 @@ export default async function PlayerProfile({
             <span>Fiche joueur</span>
             <span>ID Statisfoot : {player.id}</span>
           </div>
-          <h1 className="text-3xl font-bold text-white">{player.name}</h1>
+          <h1 className="text-3xl font-bold text-white">{playerFullName}</h1>
           <p className="text-sm text-slate-300">
-            Poste principal : <span className="font-medium text-white">{player.position}</span>
+            Poste principal : <span className="font-medium text-white">{primaryPositionLabel}</span>
           </p>
           <dl className="grid grid-cols-1 gap-4 text-sm text-slate-300 sm:grid-cols-3">
             <div>

--- a/src/app/players/new/NewPlayerForm.tsx
+++ b/src/app/players/new/NewPlayerForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -8,7 +8,9 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import {
+  POSITION_GROUP_VALUES,
   createPlayerSchema,
+  formatPrimaryPosition,
   normalizePlayerInput,
   type CreatePlayerInput,
 } from "@/lib/players";
@@ -19,26 +21,11 @@ type FeedbackState =
 
 type ServerFieldErrors = Record<string, string[]>;
 
-const positionPlaceholders = [
-  "Gardien de but",
-  "Défenseur central",
-  "Latéral gauche",
-  "Milieu défensif",
-  "Ailier droit",
-  "Attaquant de pointe",
-];
-
-function pickPlaceholder(index: number) {
-  return positionPlaceholders[index % positionPlaceholders.length] ?? "Poste principal";
-}
-
 export function NewPlayerForm() {
   const router = useRouter();
   const [feedback, setFeedback] = useState<FeedbackState>(null);
   const [serverFieldErrors, setServerFieldErrors] = useState<ServerFieldErrors | null>(null);
   const [createdPlayerId, setCreatedPlayerId] = useState<string | null>(null);
-
-  const placeholder = useMemo(() => pickPlaceholder(Date.now()), []);
 
   const {
     register,
@@ -47,7 +34,11 @@ export function NewPlayerForm() {
     reset,
   } = useForm<CreatePlayerInput>({
     resolver: zodResolver(createPlayerSchema),
-    defaultValues: { name: "", position: "" },
+    defaultValues: {
+      firstName: "",
+      lastName: "",
+      primaryPosition: "" as unknown as CreatePlayerInput["primaryPosition"],
+    },
   });
 
   const onSubmit = async (values: CreatePlayerInput) => {
@@ -77,10 +68,18 @@ export function NewPlayerForm() {
         return;
       }
 
-      const player = (await response.json()) as { id: string; name: string };
+      const player = (await response.json()) as {
+        id: string;
+        firstName: string | null;
+        lastName: string | null;
+      };
       setFeedback({ type: "success", message: "Le joueur a été ajouté avec succès." });
       setCreatedPlayerId(player.id);
-      reset({ name: "", position: "" });
+      reset({
+        firstName: "",
+        lastName: "",
+        primaryPosition: "" as unknown as CreatePlayerInput["primaryPosition"],
+      });
       router.refresh();
     } catch (error) {
       setFeedback({
@@ -90,40 +89,61 @@ export function NewPlayerForm() {
     }
   };
 
-  const nameError = errors.name?.message;
-  const positionError = errors.position?.message;
+  const firstNameError = errors.firstName?.message;
+  const lastNameError = errors.lastName?.message;
+  const primaryPositionError = errors.primaryPosition?.message;
 
-  const serverNameError = serverFieldErrors?.name?.[0];
-  const serverPositionError = serverFieldErrors?.position?.[0];
+  const serverFirstNameError = serverFieldErrors?.firstName?.[0];
+  const serverLastNameError = serverFieldErrors?.lastName?.[0];
+  const serverPrimaryPositionError = serverFieldErrors?.primaryPosition?.[0];
 
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
       className="space-y-6 rounded-2xl bg-slate-900/50 p-8 shadow-lg ring-1 ring-white/10"
     >
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid gap-6 md:grid-cols-3">
         <label className="flex flex-col gap-2 text-sm text-slate-200">
-          Nom complet du joueur
+          Prénom
           <input
-            {...register("name")}
+            {...register("firstName")}
             type="text"
-            placeholder="Ex. Enzo Leclerc"
+            placeholder="Ex. Enzo"
             className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
           />
-          {(nameError || serverNameError) && (
-            <span className="text-xs text-rose-300">{nameError || serverNameError}</span>
+          {(firstNameError || serverFirstNameError) && (
+            <span className="text-xs text-rose-300">{firstNameError || serverFirstNameError}</span>
+          )}
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-200">
+          Nom
+          <input
+            {...register("lastName")}
+            type="text"
+            placeholder="Ex. Leclerc"
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          {(lastNameError || serverLastNameError) && (
+            <span className="text-xs text-rose-300">{lastNameError || serverLastNameError}</span>
           )}
         </label>
         <label className="flex flex-col gap-2 text-sm text-slate-200">
           Poste principal
-          <input
-            {...register("position")}
-            type="text"
-            placeholder={placeholder}
-            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
-          />
-          {(positionError || serverPositionError) && (
-            <span className="text-xs text-rose-300">{positionError || serverPositionError}</span>
+          <select
+            {...register("primaryPosition")}
+            className="rounded-lg border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            <option value="">Sélectionnez un poste</option>
+            {POSITION_GROUP_VALUES.map((value) => (
+              <option key={value} value={value}>
+                {formatPrimaryPosition(value)} ({value})
+              </option>
+            ))}
+          </select>
+          {(primaryPositionError || serverPrimaryPositionError) && (
+            <span className="text-xs text-rose-300">
+              {primaryPositionError || serverPrimaryPositionError}
+            </span>
           )}
         </label>
       </div>
@@ -168,7 +188,11 @@ export function NewPlayerForm() {
         <button
           type="button"
           onClick={() => {
-            reset({ name: "", position: "" });
+            reset({
+              firstName: "",
+              lastName: "",
+              primaryPosition: "" as unknown as CreatePlayerInput["primaryPosition"],
+            });
             setServerFieldErrors(null);
             setFeedback(null);
             setCreatedPlayerId(null);

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -4,6 +4,7 @@ import type { Role } from "@prisma/client";
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatPlayerName, formatPrimaryPosition } from "@/lib/players";
 import { hasPermission, PERMISSIONS, ROLES } from "@/lib/rbac";
 
 import CreatePlayerForm from "./CreatePlayerForm";
@@ -97,12 +98,14 @@ export default async function PlayersPage() {
                     href={`/players/${player.id}`}
                     className="hover:text-accent"
                   >
-                    {player.name}
+                    {formatPlayerName(player.firstName, player.lastName)}
                   </Link>
                   <span className="block text-xs text-slate-400">ID {player.id}</span>
                 </th>
                 <td className="px-6 py-4 capitalize">
-                  {player.position.toLowerCase()}
+                  {player.primaryPosition
+                    ? formatPrimaryPosition(player.primaryPosition)
+                    : "—"}
                 </td>
                 <td className="px-6 py-4 text-sm">{player._count.reports}</td>
                 <td className="px-6 py-4 text-sm">

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatPlayerName, formatPrimaryPosition } from "@/lib/players";
 
 const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
   day: "2-digit",
@@ -29,7 +30,14 @@ export default async function ReportDetailPage({ params }: ReportPageProps) {
   const report = await prisma.report.findUnique({
     where: { id: params.id },
     include: {
-      player: { select: { id: true, name: true, position: true } },
+      player: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          primaryPosition: true,
+        },
+      },
       author: {
         select: {
           id: true,
@@ -57,11 +65,16 @@ export default async function ReportDetailPage({ params }: ReportPageProps) {
     report.author?.email ||
     "Auteur inconnu";
 
+  const playerName = formatPlayerName(report.player.firstName, report.player.lastName);
+  const playerPositionLabel = report.player.primaryPosition
+    ? formatPrimaryPosition(report.player.primaryPosition)
+    : "—";
+
   return (
     <div className="space-y-8">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-sm text-slate-400">Rapport sur {report.player.name}</p>
+          <p className="text-sm text-slate-400">Rapport sur {playerName}</p>
           <h1 className="text-3xl font-bold text-white">Rapport #{report.id}</h1>
         </div>
         <Link
@@ -84,9 +97,9 @@ export default async function ReportDetailPage({ params }: ReportPageProps) {
             <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
               Joueur
             </h3>
-            <p className="mt-2 text-lg font-semibold text-white">{report.player.name}</p>
+            <p className="mt-2 text-lg font-semibold text-white">{playerName}</p>
             <p className="text-sm text-slate-300">
-              Poste&nbsp;: {report.player.position.toLowerCase()}
+              Poste&nbsp;: {playerPositionLabel}
             </p>
             <p className="text-xs text-slate-500">ID {report.player.id}</p>
           </div>

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatPlayerName } from "@/lib/players";
 import { NewReportPageClient } from "./NewReportPageClient";
 
 /**
@@ -15,9 +16,19 @@ export default async function NewReportPage() {
   }
 
   const players = await prisma.player.findMany({
-    orderBy: { name: "asc" },
-    select: { id: true, name: true, position: true },
+    orderBy: { lastName: "asc" },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      primaryPosition: true,
+    },
   });
 
-  return <NewReportPageClient initialPlayers={players} />;
+  const payload = players.map((player) => ({
+    ...player,
+    fullName: formatPlayerName(player.firstName, player.lastName),
+  }));
+
+  return <NewReportPageClient initialPlayers={payload} />;
 }

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { formatPlayerName, formatPrimaryPosition } from "@/lib/players";
 
 const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
   day: "2-digit",
@@ -22,7 +23,14 @@ export default async function ReportsPage() {
   const reports = await prisma.report.findMany({
     where: { authorId: session.user.id },
     include: {
-      player: { select: { id: true, name: true, position: true } },
+      player: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          primaryPosition: true,
+        },
+      },
     },
     orderBy: { createdAt: "desc" },
   });
@@ -70,10 +78,16 @@ export default async function ReportsPage() {
                 className="border-b border-slate-800/60 hover:bg-slate-800/40"
               >
                 <th scope="row" className="px-6 py-4 font-medium text-white">
-                  <span className="block text-sm">{report.player.name}</span>
+                  <span className="block text-sm">
+                    {formatPlayerName(report.player.firstName, report.player.lastName)}
+                  </span>
                   <span className="block text-xs text-slate-400">ID {report.player.id}</span>
                 </th>
-                <td className="px-6 py-4 capitalize">{report.player.position.toLowerCase()}</td>
+                <td className="px-6 py-4 capitalize">
+                  {report.player.primaryPosition
+                    ? formatPrimaryPosition(report.player.primaryPosition)
+                    : "—"}
+                </td>
                 <td className="px-6 py-4 text-sm capitalize">{report.status.toLowerCase()}</td>
                 <td className="px-6 py-4 text-sm">{dateFormatter.format(report.createdAt)}</td>
                 <td className="px-6 py-4 text-right text-sm">

--- a/src/components/dashboard/MyReports.tsx
+++ b/src/components/dashboard/MyReports.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { formatPlayerName, formatPrimaryPosition } from "@/lib/players";
+
 export type DashboardReport = {
   id: string;
   status: string;
@@ -7,8 +9,9 @@ export type DashboardReport = {
   content: string;
   player: {
     id: string;
-    name: string;
-    position: string;
+    firstName: string | null;
+    lastName: string | null;
+    primaryPosition: string | null;
   };
 };
 
@@ -118,13 +121,17 @@ export function MyReports({ reports }: MyReportsProps) {
                     scope="row"
                     className="px-6 py-4 font-medium text-white"
                   >
-                    <span className="block text-sm">{report.player.name}</span>
+                    <span className="block text-sm">
+                      {formatPlayerName(report.player.firstName, report.player.lastName)}
+                    </span>
                     <span className="text-xs text-slate-400">
                       ID {report.player.id}
                     </span>
                   </th>
                   <td className="px-6 py-4 text-sm capitalize">
-                    {report.player.position.toLowerCase()}
+                    {report.player.primaryPosition
+                      ? formatPrimaryPosition(report.player.primaryPosition)
+                      : "—"}
                   </td>
                   <td className="px-6 py-4 text-sm text-slate-400">
                     {formatExcerpt(report.content)}

--- a/src/components/reports/NewReportForm.tsx
+++ b/src/components/reports/NewReportForm.tsx
@@ -3,10 +3,12 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
+import { formatPrimaryPosition } from "@/lib/players";
+
 type PlayerOption = {
   id: string;
-  name: string;
-  position: string;
+  fullName: string;
+  primaryPosition: string | null;
 };
 
 interface NewReportFormProps {
@@ -85,7 +87,10 @@ export function NewReportForm({ players }: NewReportFormProps) {
           >
             {players.map((player) => (
               <option key={player.id} value={player.id}>
-                {player.name} · {player.position.toLowerCase()}
+                {player.fullName}
+                {player.primaryPosition
+                  ? ` · ${formatPrimaryPosition(player.primaryPosition)} (${player.primaryPosition})`
+                  : ""}
               </option>
             ))}
           </select>

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -1,29 +1,47 @@
 import { z, type infer as zInfer } from "./zod";
 
-const NAME_MAX_LENGTH = 120;
-const POSITION_MAX_LENGTH = 80;
-const MIN_NAME_LENGTH = 3;
-const MIN_POSITION_LENGTH = 2;
+const FIRST_NAME_MAX_LENGTH = 60;
+const LAST_NAME_MAX_LENGTH = 80;
+const MIN_NAME_LENGTH = 2;
+
+export const POSITION_GROUP_VALUES = ["GK", "DF", "MF", "FW"] as const;
+export type PositionGroupValue = (typeof POSITION_GROUP_VALUES)[number];
+
+const POSITION_GROUP_LABELS: Record<PositionGroupValue, string> = {
+  GK: "Gardien de but",
+  DF: "Défenseur",
+  MF: "Milieu",
+  FW: "Attaquant",
+};
 
 function hasMinimumLength(value: string, minimum: number) {
   return value.trim().length >= minimum;
 }
 
 export const createPlayerSchema = z.object({
-  name: z
+  firstName: z
     .string()
-    .max(NAME_MAX_LENGTH, `Le nom ne peut pas dépasser ${NAME_MAX_LENGTH} caractères.`)
+    .max(
+      FIRST_NAME_MAX_LENGTH,
+      `Le prénom ne peut pas dépasser ${FIRST_NAME_MAX_LENGTH} caractères.`
+    )
+    .refine(
+      (value) => hasMinimumLength(value, MIN_NAME_LENGTH),
+      `Le prénom doit contenir au moins ${MIN_NAME_LENGTH} caractères.`
+    ),
+  lastName: z
+    .string()
+    .max(
+      LAST_NAME_MAX_LENGTH,
+      `Le nom ne peut pas dépasser ${LAST_NAME_MAX_LENGTH} caractères.`
+    )
     .refine(
       (value) => hasMinimumLength(value, MIN_NAME_LENGTH),
       `Le nom doit contenir au moins ${MIN_NAME_LENGTH} caractères.`
     ),
-  position: z
-    .string()
-    .max(POSITION_MAX_LENGTH, `Le poste ne peut pas dépasser ${POSITION_MAX_LENGTH} caractères.`)
-    .refine(
-      (value) => hasMinimumLength(value, MIN_POSITION_LENGTH),
-      `Le poste doit contenir au moins ${MIN_POSITION_LENGTH} caractères.`
-    ),
+  primaryPosition: z.enum(POSITION_GROUP_VALUES, {
+    errorMap: () => ({ message: "Sélectionnez un poste principal valide." }),
+  }),
 });
 
 export type CreatePlayerInput = zInfer<typeof createPlayerSchema>;
@@ -31,7 +49,27 @@ export type CreatePlayerInput = zInfer<typeof createPlayerSchema>;
 export function normalizePlayerInput(values: CreatePlayerInput) {
   const normalize = (value: string) => value.trim().replace(/\s+/g, " ");
   return {
-    name: normalize(values.name),
-    position: normalize(values.position),
+    firstName: normalize(values.firstName),
+    lastName: normalize(values.lastName),
+    primaryPosition: values.primaryPosition,
   } satisfies CreatePlayerInput;
+}
+
+export function formatPlayerName(
+  firstName: string | null | undefined,
+  lastName: string | null | undefined
+) {
+  return [firstName, lastName]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value && value.length > 0))
+    .join(" ");
+}
+
+export function formatPrimaryPosition(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+
+  const upperValue = value.toUpperCase() as (typeof POSITION_GROUP_VALUES)[number];
+  return POSITION_GROUP_LABELS[upperValue] ?? value;
 }


### PR DESCRIPTION
## Summary
- update the players API to return first/last names with derived fullName and store primaryPosition
- refresh player creation flows to capture split names and select a primary position
- adjust reports listings and forms to display concatenated player names with formatted position labels

## Testing
- npx prisma generate
- npm run lint *(fails: pre-existing lint errors about no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2483a0f0833381024330264d24e2