### PR TITLE
Expose report match dates across the app

### DIFF
--- a/prisma/migrations/20251010120000_add_report_match_date/migration.sql
+++ b/prisma/migrations/20251010120000_add_report_match_date/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Report"
+ADD COLUMN IF NOT EXISTS "matchDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -327,6 +327,7 @@ model Report {
   authorId    String
   playerId    String
   matchId     String?
+  matchDate   DateTime?
   visibility  Visibility          @default(PRIVATE)
   status      ReportStatus        @default(DRAFT)
   title       String?

--- a/src/app/api/reports/[id]/page.tsx
+++ b/src/app/api/reports/[id]/page.tsx
@@ -11,13 +11,14 @@ import Editor from "./Editor";
  
    if (!report) return <p>Report not found</p>;
  
-   return (
-     <div className="p-8">
-       <h1 className="text-2xl font-bold">{report.title}</h1>
-       <p>{report.content}</p>
-       <p>Status: {report.status}</p>
-       <p>Player: {report.player.firstName} {report.player.lastName}</p>
-       <p>Author: {report.author.name}</p>
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">{report.title}</h1>
+      <p>{report.content}</p>
+      <p>Status: {report.status}</p>
+      <p>Match observé: {report.matchDate ? report.matchDate.toISOString() : "—"}</p>
+      <p>Player: {report.player.firstName} {report.player.lastName}</p>
+      <p>Author: {report.author.name}</p>
       <Editor
         id={report.id}
         initialTitle={report.title}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -188,8 +188,16 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { playerId, title, content, rating, strengths, weaknesses, recommendation } =
-    validationResult.data;
+  const {
+    playerId,
+    title,
+    content,
+    rating,
+    strengths,
+    weaknesses,
+    recommendation,
+    matchDate,
+  } = validationResult.data;
 
   try {
     const player = await prisma.player.findUnique({
@@ -210,6 +218,7 @@ export async function POST(req: NextRequest) {
         weaknesses: weaknesses ?? undefined,
         potential: recommendation ?? undefined,
         overall: rating ?? undefined,
+        matchDate: matchDate ?? undefined,
       },
       include: {
         player: { select: PLAYER_SELECT },

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -69,6 +69,9 @@ export default async function ReportDetailPage({ params }: ReportPageProps) {
   const playerPositionLabel = report.player.primaryPosition
     ? formatPrimaryPosition(report.player.primaryPosition)
     : "—";
+  const matchDateLabel = report.matchDate
+    ? dateFormatter.format(report.matchDate)
+    : "—";
 
   return (
     <div className="space-y-8">
@@ -111,6 +114,10 @@ export default async function ReportDetailPage({ params }: ReportPageProps) {
               <div className="flex justify-between">
                 <dt>Statut</dt>
                 <dd className="capitalize">{report.status.toLowerCase()}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Match observé</dt>
+                <dd>{matchDateLabel}</dd>
               </div>
               <div className="flex justify-between">
                 <dt>Créé le</dt>

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -64,6 +64,9 @@ export default async function ReportsPage() {
                 Statut
               </th>
               <th scope="col" className="px-6 py-3">
+                Match observé
+              </th>
+              <th scope="col" className="px-6 py-3">
                 Créé le
               </th>
               <th scope="col" className="px-6 py-3">
@@ -89,6 +92,9 @@ export default async function ReportsPage() {
                     : "—"}
                 </td>
                 <td className="px-6 py-4 text-sm capitalize">{report.status.toLowerCase()}</td>
+                <td className="px-6 py-4 text-sm">
+                  {report.matchDate ? dateFormatter.format(report.matchDate) : "—"}
+                </td>
                 <td className="px-6 py-4 text-sm">{dateFormatter.format(report.createdAt)}</td>
                 <td className="px-6 py-4 text-right text-sm">
                   <Link href={`/reports/${report.id}`} className="text-accent hover:text-accent/80">

--- a/src/components/dashboard/MyReports.tsx
+++ b/src/components/dashboard/MyReports.tsx
@@ -6,6 +6,7 @@ export type DashboardReport = {
   id: string;
   status: string;
   createdAt: Date;
+  matchDate: Date | null;
   content: string;
   player: {
     id: string;
@@ -101,6 +102,9 @@ export function MyReports({ reports }: MyReportsProps) {
                   Extrait
                 </th>
                 <th scope="col" className="px-6 py-3">
+                  Match
+                </th>
+                <th scope="col" className="px-6 py-3">
                   Date
                 </th>
                 <th scope="col" className="px-6 py-3">
@@ -135,6 +139,9 @@ export function MyReports({ reports }: MyReportsProps) {
                   </td>
                   <td className="px-6 py-4 text-sm text-slate-400">
                     {formatExcerpt(report.content)}
+                  </td>
+                  <td className="px-6 py-4 text-sm">
+                    {report.matchDate ? dateFormatter.format(report.matchDate) : "—"}
                   </td>
                   <td className="px-6 py-4 text-sm">
                     {dateFormatter.format(report.createdAt)}


### PR DESCRIPTION
## Summary
- add the optional `matchDate` field to the Prisma `Report` model together with a migration
- persist the provided match date when creating reports through the API
- surface the match date in the reports listing, detail view, and dashboard widgets

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc409475588333aef6e70c057ae5bb