### PR TITLE
Restore email verification fields

### DIFF
--- a/prisma/migrations/20251101090000_reintroduce_email_verification_fields/migration.sql
+++ b/prisma/migrations/20251101090000_reintroduce_email_verification_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "emailVerificationToken" TEXT,
+ADD COLUMN     "emailVerified" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_emailVerificationToken_key" ON "public"."User"("emailVerificationToken");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,8 @@ model User {
   displayName    String
   avatarUrl      String?
   orgId          String?
+  emailVerified  DateTime?
+  emailVerificationToken String? @unique
   organization   Organization?   @relation(fields: [orgId], references: [id])
   roles          UserRole[]
   bio            String?

--- a/src/app/actions/resendVerificationEmail.ts
+++ b/src/app/actions/resendVerificationEmail.ts
@@ -7,7 +7,6 @@
  */
 
 import { auth } from "@/lib/auth";
-import type { Session } from "next-auth";
 import { prisma } from "@/lib/prisma";
 import { randomBytes } from "crypto";
 import { sendVerificationEmail } from "@/lib/email";
@@ -29,6 +28,11 @@ export async function resendVerificationEmail() {
 
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
+    select: {
+      id: true,
+      email: true,
+      emailVerified: true,
+    },
   });
 
   if (!user) {

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -9,9 +9,12 @@ export async function GET(request: Request) {
     return new NextResponse("Token manquant", { status: 400 });
   }
 
-  const user = await prisma.user.findFirst({
+  const user = await prisma.user.findUnique({
     where: {
       emailVerificationToken: token,
+    },
+    select: {
+      id: true,
     },
   });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,13 +26,15 @@ export default async function RootLayout({
  }: Readonly<{
    children: React.ReactNode;
  }>) {
-   const session = await auth();
+  const session = await auth();
+  const shouldDisplayVerificationBanner =
+    !!session?.user && !session.user.emailVerified;
 
    return (
      <html lang="fr">
        <body className={`${inter.className} antialiased`}>
          <Providers>
-           {session && !session.user?.emailVerified && <EmailVerificationBanner />}
+          {shouldDisplayVerificationBanner && <EmailVerificationBanner />}
            {children}
          </Providers>
        </body>


### PR DESCRIPTION
## Summary
- reintroduce email verification fields on the User model and add a migration
- update the resend action and verification route to work with the reinstated token
- show the verification banner only when the session user still needs to confirm their email

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc52b7d7c88333bc7604d7bd87203b