### PR TITLE
Fix duplicate User fields in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,61 +67,33 @@ model Organization {
 }
 
 model User {
-
-  id             String          @id @default(cuid())
-  email          String          @unique
-  username       String          @unique
-  hashedPass     String
-  displayName    String
-  avatarUrl      String?
-  orgId          String?
-  emailVerified  DateTime?
-  emailVerificationToken String? @unique
-  organization   Organization?   @relation(fields: [orgId], references: [id])
-  roles          UserRole[]
-  bio            String?
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  disabledAt     DateTime?
-  comments       Comment[]
-  reactions      Reaction[]
-  follows        Follow[]        @relation("user_follows")
-  followers      Follow[]        @relation("user_followers")
-  notifications  Notification[]
-  reports        Report[]        @relation("report_author")
-  auditLogs      AuditLog[]      @relation("audit_logs")
-  addedTags      PlayerTag[]     @relation("player_tags")
-  reviews        ReportReview[]  @relation("report_reviews")
-  mediaAssets    MediaAsset[]    @relation("media_assets")
-  reportVersions ReportVersion[] @relation("report_versions")
-
-  id                String                  @id @default(cuid())
-  email             String                  @unique
-  username          String                  @unique
-  hashedPass        String
-  displayName       String
-  emailVerified     DateTime?
-  avatarUrl         String?
-  orgId             String?
-  organization      Organization?           @relation(fields: [orgId], references: [id])
-  roles             UserRole[]
-  emailVerification EmailVerificationToken?
-  bio               String?
-  createdAt         DateTime                @default(now())
-  updatedAt         DateTime                @updatedAt
-  disabledAt        DateTime?
-  comments          Comment[]
-  reactions         Reaction[]
-  follows           Follow[]                @relation("user_follows")
-  followers         Follow[]                @relation("user_followers")
-  notifications     Notification[]
-  reports           Report[]                @relation("report_author")
-  auditLogs         AuditLog[]              @relation("audit_logs")
-  addedTags         PlayerTag[]             @relation("player_tags")
-  reviews           ReportReview[]          @relation("report_reviews")
-  mediaAssets       MediaAsset[]            @relation("media_assets")
-  reportVersions    ReportVersion[]         @relation("report_versions")
-
+  id                     String                  @id @default(cuid())
+  email                  String                  @unique
+  username               String                  @unique
+  hashedPass             String
+  displayName            String
+  avatarUrl              String?
+  orgId                  String?
+  emailVerified          DateTime?
+  emailVerificationToken String?                 @unique
+  emailVerification      EmailVerificationToken?
+  organization           Organization?           @relation(fields: [orgId], references: [id])
+  roles                  UserRole[]
+  bio                    String?
+  createdAt              DateTime                @default(now())
+  updatedAt              DateTime                @updatedAt
+  disabledAt             DateTime?
+  comments               Comment[]
+  reactions              Reaction[]
+  follows                Follow[]                @relation("user_follows")
+  followers              Follow[]                @relation("user_followers")
+  notifications          Notification[]
+  reports                Report[]                @relation("report_author")
+  auditLogs              AuditLog[]              @relation("audit_logs")
+  addedTags              PlayerTag[]             @relation("player_tags")
+  reviews                ReportReview[]          @relation("report_reviews")
+  mediaAssets            MediaAsset[]            @relation("media_assets")
+  reportVersions         ReportVersion[]         @relation("report_versions")
 
   @@index([orgId])
 }


### PR DESCRIPTION
## Summary
- remove duplicated field declarations from the User model in the Prisma schema
- keep a single User definition while restoring the email verification relation field
- reformat the schema after the cleanup

## Testing
- npx prisma format
- DATABASE_URL="postgresql://user:password@localhost:5432/db" npx prisma validate

------
https://chatgpt.com/codex/tasks/task_e_68dc5d54465c8333a049838344fd68ae