### PR TITLE
Fix NextAuth configuration typing and destructuring

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,49 +11,34 @@ import { prisma } from "@/lib/prisma";
 
 import type { UserRoleEnum } from "@prisma/client";
 
-import { UserRoleEnum } from "@prisma/client";
-
-
-// Augmentations de types
+// Augmentation des types NextAuth pour inclure des champs personnalisés
 declare module "next-auth" {
   interface Session {
     user?: DefaultSession["user"] & {
       id: string;
       role?: UserRoleEnum | null;
-
-      displayName?: string;
-      username?: string;
-
       displayName?: string | null;
-      username?: string;
+      username?: string | null;
       emailVerified?: Date | null;
-
     };
   }
+
   interface User {
+    id?: string;
     role?: UserRoleEnum | null;
-
-    displayName?: string;
-    username?: string;
-
     displayName?: string | null;
-    username?: string;
+    username?: string | null;
     emailVerified?: Date | null;
-
   }
 }
+
 declare module "next-auth/jwt" {
   interface JWT {
     userId?: string;
     role?: UserRoleEnum | null;
-
-    displayName?: string;
-    username?: string;
-
     displayName?: string | null;
-    username?: string;
+    username?: string | null;
     emailVerified?: Date | null;
-
   }
 }
 
@@ -75,43 +60,43 @@ export const authOptions: NextAuthOptions = {
       },
       async authorize(creds) {
         if (!creds?.email || !creds?.password) return null;
+
         const email = creds.email.toLowerCase().trim();
         const user = await prisma.user.findUnique({
           where: { email },
-
-          include: { roles: { include: { role: true } } },
-
           include: {
             roles: {
               include: { role: true },
               orderBy: { assignedAt: "asc" },
             },
           },
-
         });
+
         if (!user?.hashedPass) return null;
+
         const ok = await compare(creds.password, user.hashedPass);
         if (!ok) return null;
 
         const primaryRole = user.roles[0]?.role?.name ?? null;
 
-        const primaryRole = user.roles[0]?.role.name ?? null;
-
         return {
           id: user.id,
           name: user.displayName,
           email: user.email,
-
           image: user.avatarUrl ?? null,
           role: primaryRole,
           displayName: user.displayName,
           username: user.username,
-
-          role: primaryRole,
-          displayName: user.displayName,
-          username: user.username,
           emailVerified: user.emailVerified ?? null,
-
+        } satisfies {
+          id: string;
+          name: string;
+          email: string;
+          image: string | null;
+          role: UserRoleEnum | null;
+          displayName: string;
+          username: string;
+          emailVerified: Date | null;
         };
       },
     }),
@@ -124,34 +109,14 @@ export const authOptions: NextAuthOptions = {
           role,
           displayName,
           username,
-
-        } = user as {
-          id?: string;
-          role?: UserRoleEnum | null;
-          displayName?: string;
-          username?: string;
-        };
-
-        token.userId = id;
-        token.role = role ?? null;
-        token.displayName = displayName;
-        token.username = username;
-
           emailVerified,
-        } = user as {
-          id?: string;
-          role?: UserRoleEnum | null;
-          displayName?: string | null;
-          username?: string;
-          emailVerified?: Date | null;
-        };
+        } = user;
 
-        token.userId = id;
-        token.role = role;
+        token.userId = id ?? token.userId;
+        token.role = role ?? null;
         token.displayName = displayName ?? null;
-        token.username = username ?? undefined;
+        token.username = username ?? null;
         token.emailVerified = emailVerified ?? null;
-
       }
       return token;
     },
@@ -159,32 +124,19 @@ export const authOptions: NextAuthOptions = {
       if (!session.user) {
         session.user = {
           id: token.userId ?? "",
-
           role: token.role ?? null,
-          displayName: token.displayName,
-          username: token.username,
-        } as NonNullable<typeof session.user>;
-      } else {
-        session.user.id = token.userId ?? "";
-        session.user.role = token.role ?? null;
-        session.user.displayName = token.displayName;
-        session.user.username = token.username;
-      }
-      if (session.user) {
-        session.user.name = token.displayName ?? session.user.name;
-
-          role: token.role ?? undefined,
           displayName: token.displayName ?? null,
-          username: token.username ?? undefined,
+          username: token.username ?? null,
           emailVerified: token.emailVerified ?? null,
         } as NonNullable<typeof session.user>;
       } else {
         session.user.id = token.userId ?? "";
-        session.user.role = token.role ?? undefined;
+        session.user.role = token.role ?? null;
         session.user.displayName = token.displayName ?? null;
-        session.user.username = token.username ?? undefined;
-
+        session.user.username = token.username ?? null;
+        session.user.emailVerified = token.emailVerified ?? null;
       }
+
       if (session.user) {
         session.user.name = token.displayName ?? session.user.name;
       }


### PR DESCRIPTION
## Summary
- rewrite the NextAuth type augmentations to remove duplicated fields and include custom properties cleanly
- streamline the credentials provider authorize logic to return consistent user metadata
- ensure JWT and session callbacks persist custom fields without duplicate assignments

## Testing
- npm run lint *(fails: existing lint and parsing issues in unrelated files)*
- npm run dev *(fails: Next.js lockfile patch requires network access and returns ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5f517b688333bca77fd7af57b600