### PR TITLE
Ensure email verification columns exist for User

### DIFF
--- a/prisma/migrations/20251115120000_fix_missing_email_verified_column/migration.sql
+++ b/prisma/migrations/20251115120000_fix_missing_email_verified_column/migration.sql
@@ -1,0 +1,18 @@
+-- Ensure email verification columns exist on User table
+ALTER TABLE "public"."User"
+  ADD COLUMN IF NOT EXISTS "emailVerified" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "emailVerificationToken" TEXT;
+
+-- Ensure unique index exists for email verification tokens
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'User_emailVerificationToken_key'
+  ) THEN
+    CREATE UNIQUE INDEX "User_emailVerificationToken_key"
+      ON "public"."User" ("emailVerificationToken");
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a migration that idempotently adds the email verification columns on the User table
- guard creation of the unique index so repeated deploys succeed

## Testing
- not run (migration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc696a9de0833391b1ba6e6b62df14