### PR TITLE
Harden Prisma bootstrap for email verification fields

### DIFF
--- a/prisma/migrations/20251115120000_fix_missing_email_verified_column/migration.sql
+++ b/prisma/migrations/20251115120000_fix_missing_email_verified_column/migration.sql
@@ -1,0 +1,8 @@
+-- Ensure email verification columns exist on User table
+ALTER TABLE "public"."User"
+  ADD COLUMN IF NOT EXISTS "emailVerified" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "emailVerificationToken" TEXT;
+
+-- Ensure unique index exists for email verification tokens
+CREATE UNIQUE INDEX IF NOT EXISTS "User_emailVerificationToken_key"
+  ON "public"."User" ("emailVerificationToken");

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -6,7 +6,13 @@
  */
 import { PrismaClient } from "@prisma/client";
 
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+type BootstrapGlobals = {
+  prisma?: PrismaClient;
+  prismaBootstrapPromise?: Promise<void>;
+  prismaBootstrapMiddlewareRegistered?: boolean;
+};
+
+const globalForPrisma = globalThis as unknown as BootstrapGlobals;
 
 /**
  * @const {PrismaClient} prisma
@@ -20,5 +26,100 @@ export const prisma =
   new PrismaClient({
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   });
+
+type SupportedProvider = "postgresql" | "sqlite";
+
+function inferProvider(url: string | undefined): SupportedProvider {
+  if (!url) return "postgresql";
+
+  const lowered = url.toLowerCase();
+  if (lowered.startsWith("file:")) return "sqlite";
+  if (lowered.includes(":memory:")) return "sqlite";
+  if (lowered.includes("sqlite")) return "sqlite";
+
+  return "postgresql";
+}
+
+function escapeIdentifier(identifier: string): string {
+  return identifier.replace(/"/g, '""');
+}
+
+function resolvePostgresSchema(url: string | undefined): string {
+  if (!url) return "public";
+
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get("schema") ?? "public";
+  } catch (error) {
+    console.warn("Unable to parse DATABASE_URL, defaulting to public schema", error);
+    return "public";
+  }
+}
+
+async function ensureEmailVerificationColumns(
+  client: PrismaClient,
+  provider: SupportedProvider,
+): Promise<void> {
+  if (provider === "sqlite") {
+    const columns = (await client.$queryRawUnsafe<Array<{ name: string }>>(
+      'PRAGMA table_info("User")',
+    )) as Array<{ name: string }>;
+
+    const hasEmailVerified = columns.some((column) => column.name === "emailVerified");
+    const hasEmailVerificationToken = columns.some(
+      (column) => column.name === "emailVerificationToken",
+    );
+
+    if (!hasEmailVerified) {
+      await client.$executeRawUnsafe('ALTER TABLE "User" ADD COLUMN "emailVerified" DATETIME');
+    }
+
+    if (!hasEmailVerificationToken) {
+      await client.$executeRawUnsafe(
+        'ALTER TABLE "User" ADD COLUMN "emailVerificationToken" TEXT',
+      );
+    }
+
+    await client.$executeRawUnsafe(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "User_emailVerificationToken_key" ON "User"("emailVerificationToken")',
+    );
+
+    return;
+  }
+
+  const schema = escapeIdentifier(resolvePostgresSchema(process.env.DATABASE_URL));
+
+  await client.$executeRawUnsafe(`
+    ALTER TABLE "${schema}"."User"
+    ADD COLUMN IF NOT EXISTS "emailVerified" TIMESTAMP(3),
+    ADD COLUMN IF NOT EXISTS "emailVerificationToken" TEXT
+  `);
+
+  await client.$executeRawUnsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS "User_emailVerificationToken_key"
+    ON "${schema}"."User" ("emailVerificationToken")
+  `);
+}
+
+const bootstrapPromise =
+  globalForPrisma.prismaBootstrapPromise ??
+  ensureEmailVerificationColumns(prisma, inferProvider(process.env.DATABASE_URL)).catch(
+    (error) => {
+      console.error("Failed to ensure email verification columns exist", error);
+      throw error;
+    },
+  );
+
+if (!globalForPrisma.prismaBootstrapPromise) {
+  globalForPrisma.prismaBootstrapPromise = bootstrapPromise;
+}
+
+if (!globalForPrisma.prismaBootstrapMiddlewareRegistered) {
+  prisma.$use(async (params, next) => {
+    await bootstrapPromise;
+    return next(params);
+  });
+  globalForPrisma.prismaBootstrapMiddlewareRegistered = true;
+}
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- ensure the Prisma client bootstrap creates the email verification columns and unique index across both PostgreSQL and SQLite deployments before any queries execute
- guard Prisma operations behind the one-time bootstrap promise so registration and login always wait for the schema to be up to date
- simplify the remediation migration to rely on `CREATE UNIQUE INDEX IF NOT EXISTS` for the token constraint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc696a9de0833391b1ba6e6b62df14