### PR TITLE
Add admin role seeding and dashboard role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ Pour lancer le projet en local, suivez les étapes ci-dessous.
     npx prisma migrate dev
     ```
 
-5.  **Lancez le serveur de développement** :
+5.  **Initialisez les rôles et, si besoin, un compte administrateur** :
+    Le script de seed garantit que la table `Role` contient toutes les valeurs attendues et peut créer un compte `ADMIN` si vous
+    fournissez les variables d'environnement `SEED_ADMIN_EMAIL` et `SEED_ADMIN_PASSWORD` (et optionnellement `SEED_ADMIN_NAME`).
+
+    ```bash
+    npx prisma db seed
+    ```
+
+6.  **Lancez le serveur de développement** :
     ```bash
     npm run dev
     ```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
       "react-chartjs-2": "^5.2.0",
       "react-dom": "^18.2.0"
    },
+   "prisma": {
+      "seed": "node prisma/seed.js"
+   },
    "devDependencies": {
       "@eslint/eslintrc": "^3",
       "@tailwindcss/postcss": "^4",

--- a/prisma/migrations/20251120100000_add_agent_role_to_enum/migration.sql
+++ b/prisma/migrations/20251120100000_add_agent_role_to_enum/migration.sql
@@ -1,0 +1,13 @@
+-- Add missing AGENT role to the enum to keep database aligned with Prisma schema
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_enum e ON t.oid = e.enumtypid
+    WHERE t.typname = 'UserRoleEnum'
+      AND e.enumlabel = 'AGENT'
+  ) THEN
+    ALTER TYPE "public"."UserRoleEnum" ADD VALUE 'AGENT';
+  END IF;
+END $$;

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,128 @@
+const { PrismaClient, UserRoleEnum } = require("@prisma/client");
+const { hash } = require("bcryptjs");
+
+const prisma = new PrismaClient();
+
+const roleValues = Object.values(UserRoleEnum);
+
+function buildBaseUsername(email) {
+  const [localPart = ""] = email.split("@");
+  const sanitized = localPart
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .replace(/^[._-]+/, "")
+    .replace(/[._-]+$/, "");
+  return sanitized || "admin";
+}
+
+async function findAvailableUsername(base) {
+  let candidate = base;
+  let suffix = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const existing = await prisma.user.findUnique({ where: { username: candidate } });
+    if (!existing) return candidate;
+    candidate = `${base}${suffix}`;
+    suffix += 1;
+  }
+}
+
+function buildDisplayName(email, fallbackUsername) {
+  const [localPart = ""] = email.split("@");
+  if (localPart) {
+    return localPart
+      .split(/[._-]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+  return fallbackUsername.charAt(0).toUpperCase() + fallbackUsername.slice(1);
+}
+
+async function ensureRoles() {
+  for (const roleName of roleValues) {
+    // eslint-disable-next-line no-await-in-loop
+    await prisma.role.upsert({
+      where: { name: roleName },
+      update: {},
+      create: { name: roleName },
+    });
+  }
+}
+
+async function ensureAdminAccount() {
+  const adminEmail = process.env.SEED_ADMIN_EMAIL;
+  const adminPassword = process.env.SEED_ADMIN_PASSWORD;
+  const adminDisplayName = process.env.SEED_ADMIN_NAME;
+
+  if (!adminEmail || !adminPassword) {
+    console.info(
+      "[seed] SEED_ADMIN_EMAIL or SEED_ADMIN_PASSWORD not provided: skipping admin account creation.",
+    );
+    return;
+  }
+
+  const normalizedEmail = adminEmail.trim().toLowerCase();
+  const baseUsername = buildBaseUsername(normalizedEmail);
+  const username = await findAvailableUsername(baseUsername);
+  const displayName = adminDisplayName?.trim() || buildDisplayName(normalizedEmail, username);
+  const hashedPass = await hash(adminPassword, 10);
+
+  const adminRole = await prisma.role.findUnique({ where: { name: UserRoleEnum.ADMIN } });
+  if (!adminRole) {
+    throw new Error("ADMIN role is missing from the Role table. Run ensureRoles() first.");
+  }
+
+  const user = await prisma.user.upsert({
+    where: { email: normalizedEmail },
+    update: {
+      hashedPass,
+      displayName,
+      disabledAt: null,
+      emailVerified: new Date(),
+    },
+    create: {
+      email: normalizedEmail,
+      username,
+      displayName,
+      hashedPass,
+      emailVerified: new Date(),
+      roles: {
+        create: {
+          role: { connect: { id: adminRole.id } },
+        },
+      },
+    },
+  });
+
+  await prisma.userRole.upsert({
+    where: {
+      userId_roleId: {
+        userId: user.id,
+        roleId: adminRole.id,
+      },
+    },
+    update: {},
+    create: {
+      userId: user.id,
+      roleId: adminRole.id,
+    },
+  });
+
+  console.info(`[seed] Admin account ready for ${normalizedEmail}`);
+}
+
+async function main() {
+  await ensureRoles();
+  await ensureAdminAccount();
+}
+
+main()
+  .catch((error) => {
+    console.error("[seed] Failed to seed database", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { auth } from "@/lib/auth";
+import { hasPermission, PERMISSIONS, ROLES, type AppRole } from "@/lib/rbac";
+import { prisma } from "@/lib/prisma";
+
+export type RoleUpdateState =
+  | { status: "idle" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+const ROLE_OPTIONS = new Set<AppRole>(Object.values(ROLES));
+
+export async function assignPrimaryRole(
+  _prevState: RoleUpdateState,
+  formData: FormData,
+): Promise<RoleUpdateState> {
+  const session = await auth();
+
+  const role = session?.user?.role as AppRole | undefined;
+  if (!role || !hasPermission(role, PERMISSIONS["admin:access"])) {
+    return { status: "error", message: "Accès refusé" };
+  }
+
+  const userId = String(formData.get("userId") ?? "").trim();
+  const requestedRole = String(formData.get("role") ?? "").trim().toUpperCase() as AppRole;
+
+  if (!userId) {
+    return { status: "error", message: "Identifiant utilisateur manquant" };
+  }
+
+  if (!ROLE_OPTIONS.has(requestedRole)) {
+    return { status: "error", message: "Rôle sélectionné invalide" };
+  }
+
+  const roleRecord = await prisma.role.findUnique({ where: { name: requestedRole } });
+  if (!roleRecord) {
+    return { status: "error", message: "Rôle introuvable en base" };
+  }
+
+  const userExists = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
+  if (!userExists) {
+    return { status: "error", message: "Utilisateur introuvable" };
+  }
+
+  await prisma.$transaction([
+    prisma.userRole.deleteMany({
+      where: {
+        userId,
+        NOT: { roleId: roleRecord.id },
+      },
+    }),
+    prisma.userRole.upsert({
+      where: {
+        userId_roleId: { userId, roleId: roleRecord.id },
+      },
+      update: {},
+      create: {
+        userId,
+        roleId: roleRecord.id,
+      },
+    }),
+  ]);
+
+  revalidatePath("/admin");
+  return { status: "success", message: "Rôle mis à jour" };
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
-import { PrismaClient } from "@prisma/client";
+import { RoleAssignmentForm } from "./role-assignment-form";
 
-const prisma = new PrismaClient();
+import { prisma } from "@/lib/prisma";
+import { ROLES } from "@/lib/rbac";
 
 /**
  * @page AdminDashboard
@@ -9,17 +10,79 @@ const prisma = new PrismaClient();
  * @returns {Promise<JSX.Element>} Le composant de la page du tableau de bord administrateur.
  */
 export default async function AdminDashboard() {
-  const [users, reports, players] = await Promise.all([
+  const [users, reports, players, latestUsers] = await Promise.all([
     prisma.user.count(),
     prisma.report.count(),
     prisma.player.count(),
+    prisma.user.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 20,
+      include: {
+        roles: {
+          include: { role: true },
+          orderBy: { assignedAt: "asc" },
+        },
+      },
+    }),
   ]);
 
+  const availableRoles = Object.values(ROLES);
+
   return (
-    <div className="p-8 grid grid-cols-3 gap-4">
-      <div className="card">Users: {users}</div>
-      <div className="card">Reports: {reports}</div>
-      <div className="card">Players: {players}</div>
+    <div className="space-y-8 p-8">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-neutral-500">Utilisateurs</p>
+          <p className="mt-2 text-3xl font-semibold text-neutral-900">{users}</p>
+        </div>
+        <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-neutral-500">Rapports</p>
+          <p className="mt-2 text-3xl font-semibold text-neutral-900">{reports}</p>
+        </div>
+        <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-medium text-neutral-500">Joueurs</p>
+          <p className="mt-2 text-3xl font-semibold text-neutral-900">{players}</p>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-neutral-200 bg-white shadow-sm">
+        <header className="border-b border-neutral-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-neutral-900">
+            Gestion des rôles utilisateurs
+          </h2>
+          <p className="mt-1 text-sm text-neutral-500">
+            Promotez ou rétrogradez un utilisateur vers l&apos;un des rôles supportés.
+          </p>
+        </header>
+        <div className="divide-y divide-neutral-200">
+          {latestUsers.length === 0 ? (
+            <p className="px-6 py-8 text-sm text-neutral-500">
+              Aucun utilisateur trouvé.
+            </p>
+          ) : (
+            latestUsers.map((user) => {
+              const primaryRole = user.roles[0]?.role?.name ?? null;
+
+              return (
+                <article
+                  key={user.id}
+                  className="flex flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between"
+                >
+                  <div>
+                    <p className="text-sm font-semibold text-neutral-900">{user.displayName}</p>
+                    <p className="text-sm text-neutral-500">{user.email}</p>
+                  </div>
+                  <RoleAssignmentForm
+                    userId={user.id}
+                    currentRole={primaryRole}
+                    roles={availableRoles}
+                  />
+                </article>
+              );
+            })
+          )}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/admin/role-assignment-form.tsx
+++ b/src/app/admin/role-assignment-form.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useFormState } from "react-dom";
+
+import { assignPrimaryRole, type RoleUpdateState } from "./actions";
+
+const INITIAL_STATE: RoleUpdateState = { status: "idle" };
+
+type RoleAssignmentFormProps = {
+  userId: string;
+  currentRole: string | null;
+  roles: string[];
+};
+
+export function RoleAssignmentForm({ userId, currentRole, roles }: RoleAssignmentFormProps) {
+  const [state, formAction] = useFormState(assignPrimaryRole, INITIAL_STATE);
+
+  return (
+    <form action={formAction} className="flex items-center gap-2">
+      <input type="hidden" name="userId" value={userId} />
+      <label className="sr-only" htmlFor={`role-${userId}`}>
+        Rôle principal
+      </label>
+      <select
+        id={`role-${userId}`}
+        name="role"
+        defaultValue={currentRole ?? roles[0] ?? ""}
+        className="rounded border border-neutral-300 px-2 py-1 text-sm"
+      >
+        {roles.map((role) => (
+          <option key={role} value={role}>
+            {role}
+          </option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="rounded bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700"
+      >
+        Mettre à jour
+      </button>
+      {state.status === "error" && (
+        <p className="text-sm text-red-600" role="alert">
+          {state.message}
+        </p>
+      )}
+      {state.status === "success" && (
+        <p className="text-sm text-emerald-600" role="status">
+          {state.message}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/src/app/api/reports/[id]/page.tsx
+++ b/src/app/api/reports/[id]/page.tsx
@@ -1,29 +1,26 @@
-import { PrismaClient } from "@prisma/client";
 import Editor from "./Editor";
 
- const prisma = new PrismaClient();
- 
- export default async function ReportPage({ params }: { params: { id: string } }) {
-   const report = await prisma.report.findUnique({
-     where: { id: params.id },
-     include: { author: true, player: true },
-   });
- 
-   if (!report) return <p>Report not found</p>;
- 
+import { prisma } from "@/lib/prisma";
+
+export default async function ReportPage({ params }: { params: { id: string } }) {
+  const report = await prisma.report.findUnique({
+    where: { id: params.id },
+    include: { author: true, player: true },
+  });
+
+  if (!report) return <p>Report not found</p>;
+
   return (
     <div className="p-8">
       <h1 className="text-2xl font-bold">{report.title}</h1>
       <p>{report.content}</p>
       <p>Status: {report.status}</p>
       <p>Match observé: {report.matchDate ? report.matchDate.toISOString() : "—"}</p>
-      <p>Player: {report.player.firstName} {report.player.lastName}</p>
+      <p>
+        Player: {report.player.firstName} {report.player.lastName}
+      </p>
       <p>Author: {report.author.name}</p>
-      <Editor
-        id={report.id}
-        initialTitle={report.title}
-        initialContent={report.content}
-      />
-     </div>
-   );
- }
+      <Editor id={report.id} initialTitle={report.title} initialContent={report.content} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure Prisma bootstrap syncs role records and add a migration for the missing AGENT enum value
- provide a Prisma seed script that prepares roles and optionally creates an admin account
- enhance the admin dashboard with shared Prisma usage and a role assignment workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4068024408333978e032cf5c1d350