### PR TITLE
Fix Prisma bootstrap for Prisma 6

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -8,8 +8,8 @@ import { PrismaClient, UserRoleEnum } from "@prisma/client";
 
 type BootstrapGlobals = {
   prisma?: PrismaClient;
+  prismaWithBootstrap?: PrismaClient;
   prismaBootstrapPromise?: Promise<void>;
-  prismaBootstrapMiddlewareRegistered?: boolean;
 };
 
 const globalForPrisma = globalThis as unknown as BootstrapGlobals;
@@ -21,7 +21,7 @@ const globalForPrisma = globalThis as unknown as BootstrapGlobals;
  * En production, une nouvelle instance est créée.
  * Les logs de requêtes sont activés en développement.
  */
-export const prisma =
+const basePrismaClient =
   globalForPrisma.prisma ??
   new PrismaClient({
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
@@ -42,6 +42,10 @@ function inferProvider(url: string | undefined): SupportedProvider {
 
 function escapeIdentifier(identifier: string): string {
   return identifier.replace(/"/g, '""');
+}
+
+function escapeLiteral(value: string): string {
+  return value.replace(/'/g, "''");
 }
 
 function resolvePostgresSchema(url: string | undefined): string {
@@ -101,6 +105,40 @@ async function ensureEmailVerificationColumns(
   `);
 }
 
+async function ensureUserRoleEnumValues(
+  client: PrismaClient,
+  provider: SupportedProvider,
+): Promise<void> {
+  if (provider !== "postgresql") return;
+
+  const schema = resolvePostgresSchema(process.env.DATABASE_URL);
+  const enumName = "UserRoleEnum";
+
+  const existingValues = await client.$queryRaw<Array<{ enumlabel: string }>>`
+    SELECT e.enumlabel
+    FROM pg_type t
+    JOIN pg_enum e ON t.oid = e.enumtypid
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = ${schema} AND t.typname = ${enumName}
+  `;
+
+  const existingLabels = new Set(existingValues.map((row) => row.enumlabel));
+  const missingValues = Object.values(UserRoleEnum).filter(
+    (value) => !existingLabels.has(value),
+  );
+
+  if (missingValues.length === 0) return;
+
+  const escapedSchema = escapeIdentifier(schema);
+  const escapedEnumName = escapeIdentifier(enumName);
+
+  for (const value of missingValues) {
+    await client.$executeRawUnsafe(
+      `ALTER TYPE "${escapedSchema}"."${escapedEnumName}" ADD VALUE IF NOT EXISTS '${escapeLiteral(value)}'`,
+    );
+  }
+}
+
 async function ensureRolesExist(client: PrismaClient): Promise<void> {
   const roleValues = Object.values(UserRoleEnum);
 
@@ -118,12 +156,13 @@ async function ensureRolesExist(client: PrismaClient): Promise<void> {
 async function bootstrapDatabase(client: PrismaClient): Promise<void> {
   const provider = inferProvider(process.env.DATABASE_URL);
   await ensureEmailVerificationColumns(client, provider);
+  await ensureUserRoleEnumValues(client, provider);
   await ensureRolesExist(client);
 }
 
 const bootstrapPromise =
   globalForPrisma.prismaBootstrapPromise ??
-  bootstrapDatabase(prisma).catch((error) => {
+  bootstrapDatabase(basePrismaClient).catch((error) => {
     console.error("Failed to bootstrap Prisma dependencies", error);
     throw error;
   });
@@ -132,12 +171,25 @@ if (!globalForPrisma.prismaBootstrapPromise) {
   globalForPrisma.prismaBootstrapPromise = bootstrapPromise;
 }
 
-if (!globalForPrisma.prismaBootstrapMiddlewareRegistered) {
-  prisma.$use(async (params, next) => {
-    await bootstrapPromise;
-    return next(params);
+const prismaWithBootstrap =
+  globalForPrisma.prismaWithBootstrap ??
+  basePrismaClient.$extends({
+    query: {
+      $allModels: {
+        async $allOperations({ args, query }) {
+          await bootstrapPromise;
+          return query(args);
+        },
+      },
+    },
   });
-  globalForPrisma.prismaBootstrapMiddlewareRegistered = true;
+
+if (!globalForPrisma.prismaWithBootstrap) {
+  globalForPrisma.prismaWithBootstrap = prismaWithBootstrap;
 }
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+if (process.env.NODE_ENV !== "production" && !globalForPrisma.prisma) {
+  globalForPrisma.prisma = basePrismaClient;
+}
+
+export const prisma = prismaWithBootstrap;


### PR DESCRIPTION
## Summary
- replace the deprecated Prisma middleware usage with a query extension so bootstrap waits for schema setup on Prisma 6
- ensure missing enum values are added to the Postgres UserRoleEnum before seeding default roles
- harden string escaping helpers used for dynamic SQL statements during bootstrap

## Testing
- `npm run lint` *(fails: existing @typescript-eslint/no-require-imports errors in prisma/seed.js and scripts/check-admin.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e433fab32083339fc85bbd3e36488c