### PR TITLE
Define Tailwind primary color for report submission button

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
         "dark-start": "#0B1D34",
         "dark-end": "#0E2442",
         accent: "#5BC4FF",
+        primary: "#2563EB",
         success: "#10B981",
         warning: "#F59E0B",
         danger: "#EF4444",


### PR DESCRIPTION
## Summary
- add a Tailwind `primary` color token so primary buttons render with a visible background

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-require-imports errors in prisma/seed.js and scripts/check-admin.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e4422e2bdc83339c7cf6b1c4755810