### PR TITLE
Ensure report submission includes credentials

### DIFF
--- a/src/app/reports/new/form-utils.ts
+++ b/src/app/reports/new/form-utils.ts
@@ -90,6 +90,7 @@ export async function submitReport(
   const response = await fetchImpl("/api/reports", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(payload),
   });
 

--- a/tests/reports-new.test.ts
+++ b/tests/reports-new.test.ts
@@ -78,6 +78,7 @@ const tests: TestCase[] = [
       const [, options] = calls[0];
       const requestInit = options ?? {};
       assert.equal(requestInit.method, "POST");
+      assert.equal(requestInit.credentials, "include");
       assert.ok(requestInit.body);
       const body = JSON.parse(String(requestInit.body));
       assert.deepEqual(body, payload);


### PR DESCRIPTION
## Summary
- send report creation requests with credentials so authenticated cookies reach the API
- cover the expectation in the submitReport unit test to guard against regressions

## Testing
- npm test -- tests/reports-new.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e445a8b3848333bba9eb3e9954ce8d