### PR TITLE
Fix report submission button disabled while player list refreshes

### DIFF
--- a/src/app/reports/new/NewReportPageClient.tsx
+++ b/src/app/reports/new/NewReportPageClient.tsx
@@ -438,10 +438,17 @@ export function NewReportPageClient({
             >
               Réinitialiser
             </button>
+            {/**
+             * Le bouton d'enregistrement doit rester accessible tant qu'un joueur est sélectionné,
+             * même si la liste des joueurs est en cours d'actualisation. On ne le désactive donc que
+             * lorsque la soumission est en cours ou qu'aucun joueur n'est encore disponible.
+             */}
             <button
               type="submit"
               className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
-              disabled={isSubmitting || playersLoading}
+              disabled={
+                isSubmitting || (playersLoading && players.length === 0)
+              }
             >
               {isSubmitting ? "Enregistrement…" : "Enregistrer"}
             </button>


### PR DESCRIPTION
## Summary
- keep the report submission button enabled whenever a player is already selected, even if the player list is refreshing in the background
- document why the button is only disabled when no players are yet available or a submission is in progress

## Testing
- npm run lint *(fails: existing CommonJS usage in prisma/seed.js and scripts/check-admin.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e449c3d8288333a6fd382e7bcf224f